### PR TITLE
METI職員：人物検索UI改善:

### DIFF
--- a/src/components/blocks/LoginForm.tsx
+++ b/src/components/blocks/LoginForm.tsx
@@ -5,9 +5,13 @@ import { useRouter } from "next/navigation";
 
 type SubmitState = "idle" | "submitting" | "error" | "success";
 
-// 仮ログイン認証情報（本番環境では適切な認証システムに置き換える）
-const DEMO_EMAIL = process.env.NEXT_PUBLIC_DEMO_EMAIL || "demo@example.com";
-const DEMO_PASSWORD = process.env.NEXT_PUBLIC_DEMO_PASSWORD || "demo123";
+// 🚨 セキュリティ警告: 本番環境では絶対に使用しない
+// デモ用の認証情報は環境変数で管理し、適切な認証システムに置き換える
+const DEMO_EMAIL = process.env.NEXT_PUBLIC_DEMO_EMAIL || "";
+const DEMO_PASSWORD = process.env.NEXT_PUBLIC_DEMO_PASSWORD || "";
+
+// デモ環境チェック
+const isDemoMode = process.env.NODE_ENV === "development";
 
 export default function LoginForm() {
   const router = useRouter();
@@ -29,7 +33,16 @@ export default function LoginForm() {
         throw new Error("メールアドレスとパスワードを入力してください");
       }
       
-      // 仮ログイン認証
+      // デモモード認証チェック
+      if (!isDemoMode) {
+        throw new Error("本番環境では適切な認証システムを実装してください");
+      }
+      
+      if (!DEMO_EMAIL || !DEMO_PASSWORD) {
+        throw new Error("環境変数 NEXT_PUBLIC_DEMO_EMAIL と NEXT_PUBLIC_DEMO_PASSWORD を設定してください");
+      }
+      
+      // デモ認証
       if (email === DEMO_EMAIL && password === DEMO_PASSWORD) {
         setState("success");
         // ダッシュボードに遷移

--- a/src/components/blocks/SearchPage.tsx
+++ b/src/components/blocks/SearchPage.tsx
@@ -8,9 +8,7 @@ import { NetworkMap } from "@/components/ui/network-map";
 import { 
   policyThemes, 
   industryOptions, 
-  positionOptions, 
-  regionOptions, 
-  otherOptions 
+  positionOptions 
 } from "@/data/search-data";
 import { SearchFilters } from "@/types";
 
@@ -22,9 +20,7 @@ export function SearchPage() {
     searchQuery: "",
     policyThemes: [],
     industries: [],
-    positions: [],
-    regions: [],
-    others: []
+    positions: []
   });
 
   const handleFilterChange = (key: keyof SearchFilters, value: string | string[]) => {
@@ -41,6 +37,11 @@ export function SearchPage() {
         ? prev.policyThemes.filter(id => id !== themeId)
         : [...prev.policyThemes, themeId]
     }));
+  };
+
+  const handleSearch = () => {
+    // 検索実行ロジック（現在は状態更新のみ）
+    console.log("検索実行:", filters);
   };
 
   const handleGoToDashboard = () => {
@@ -99,7 +100,7 @@ export function SearchPage() {
             
             <div className="bg-white rounded-lg p-3 h-full overflow-y-auto">
               {/* 政策テーマセレクター */}
-              <div className="mb-3">
+              <div className="mb-5">
                 <PolicyThemeSelector
                   themes={policyThemes}
                   selectedThemes={filters.policyThemes}
@@ -108,7 +109,7 @@ export function SearchPage() {
               </div>
               
               {/* その他のフィルターオプション */}
-              <div className="space-y-3">
+              <div className="space-y-4">
                 <FilterSelect
                   title="業界・分野"
                   options={industryOptions}
@@ -125,21 +126,42 @@ export function SearchPage() {
                   placeholder="役職を選択してください"
                 />
                 
-                <FilterSelect
-                  title="地域"
-                  options={regionOptions}
-                  selectedValues={filters.regions}
-                  onSelectionChange={(values) => handleFilterChange("regions", values)}
-                  placeholder="地域を選択してください"
-                />
-                
-                <FilterSelect
-                  title="その他"
-                  options={otherOptions}
-                  selectedValues={filters.others}
-                  onSelectionChange={(values) => handleFilterChange("others", values)}
-                  placeholder="その他の条件を選択してください"
-                />
+                {/* フリーワード検索 */}
+                <div>
+                  <label className="block text-xs font-medium text-gray-700 mb-2">
+                    フリーワード検索
+                  </label>
+                  <div className="relative">
+                    <div className="absolute inset-y-0 left-0 flex items-center pl-3">
+                      <span 
+                        className="material-symbols-outlined text-gray-400"
+                        style={{ fontSize: '15px' }}
+                      >
+                        search
+                      </span>
+                    </div>
+                    <input
+                      type="text"
+                      value={filters.searchQuery}
+                      onChange={(e) => handleFilterChange("searchQuery", e.target.value)}
+                      onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
+                      placeholder="キーワードを入力してください"
+                      className="w-full pl-8 pr-12 py-2 bg-gray-100 rounded border border-gray-200 text-xs placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#58aadb] focus:border-transparent transition-colors"
+                    />
+                    <button
+                      type="button"
+                      onClick={handleSearch}
+                      className="absolute inset-y-0 right-0 flex items-center pr-3 hover:bg-gray-200 rounded-r transition-colors"
+                    >
+                      <span 
+                        className="material-symbols-outlined text-gray-500 hover:text-[#58aadb] transition-colors"
+                        style={{ fontSize: '12px' }}
+                      >
+                        keyboard_return
+                      </span>
+                    </button>
+                  </div>
+                </div>
               </div>
             </div>
           </div>

--- a/src/components/ui/filter-select.tsx
+++ b/src/components/ui/filter-select.tsx
@@ -25,6 +25,24 @@ export function FilterSelect({
   className,
 }: FilterSelectProps) {
   const [isOpen, setIsOpen] = React.useState(false);
+  const containerRef = React.useRef<HTMLDivElement>(null);
+
+  // 外側クリック検知でドロップダウンを閉じる
+  React.useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isOpen]);
 
   const handleOptionToggle = (value: string) => {
     const newValues = selectedValues.includes(value)
@@ -34,8 +52,8 @@ export function FilterSelect({
   };
 
   return (
-    <div className={cn("relative", className)}>
-      <label className="block text-xs font-medium text-gray-700 mb-1">
+    <div className={cn("relative", className)} ref={containerRef}>
+      <label className="block text-xs font-medium text-gray-700 mb-2">
         {title}
       </label>
       <div
@@ -47,7 +65,7 @@ export function FilterSelect({
             {selectedValues.length === 0 ? (
               <span className="text-gray-500 text-xs">{placeholder}</span>
             ) : (
-              <div className="flex flex-wrap gap-1">
+              <div className="flex flex-wrap gap-2">
                 {selectedValues.map((value) => {
                   const option = options.find((opt) => opt.value === value);
                   return (
@@ -71,7 +89,10 @@ export function FilterSelect({
               </div>
             )}
           </div>
-          <span className="material-symbols-outlined text-gray-400 text-sm">
+          <span 
+            className="material-symbols-outlined text-gray-400"
+            style={{ fontSize: '12px' }}
+          >
             {isOpen ? "expand_less" : "expand_more"}
           </span>
         </div>

--- a/src/components/ui/policy-theme-selector.tsx
+++ b/src/components/ui/policy-theme-selector.tsx
@@ -24,31 +24,23 @@ export function PolicyThemeSelector({
 }: PolicyThemeSelectorProps) {
   return (
     <div className={cn("space-y-2", className)}>
-      <h4 className="text-xs font-medium text-gray-700 mb-2">政策テーマを選択</h4>
+      <h4 className="text-xs font-medium text-gray-700 mb-3">政策テーマを選択</h4>
       
-      <div className="grid grid-cols-3 gap-1">
+      <div className="flex flex-wrap gap-2">
         {themes.map((theme) => {
           const isSelected = selectedThemes.includes(theme.id);
           return (
             <div
               key={theme.id}
               className={cn(
-                "relative px-2 py-1 rounded-full text-[9px] font-medium transition-all cursor-pointer text-center flex items-center justify-center min-h-[20px]",
+                "px-2 py-1 rounded-full text-[9px] font-medium transition-all cursor-pointer text-center flex items-center justify-center min-h-[20px] inline-flex whitespace-nowrap",
                 isSelected
-                  ? "text-white"
+                  ? "bg-[#58aadb] text-white"
                   : "bg-gray-100 text-gray-700 hover:bg-gray-200"
               )}
-              style={isSelected ? { backgroundColor: theme.color } : {}}
               onClick={() => onThemeToggle(theme.id)}
             >
-              {isSelected && (
-                <span className="absolute left-1 top-1/2 transform -translate-y-1/2 text-white text-[8px]">
-                  ✓
-                </span>
-              )}
-              <span className={isSelected ? "ml-1" : ""}>
-                {theme.title}
-              </span>
+              {theme.title}
             </div>
           );
         })}
@@ -58,7 +50,7 @@ export function PolicyThemeSelector({
       {selectedThemes.length > 0 && (
         <button
           onClick={() => selectedThemes.forEach(id => onThemeToggle(id))}
-          className="w-full py-1 text-[9px] text-gray-600 hover:text-gray-800 transition-colors mt-2"
+          className="w-full py-1 text-[9px] text-gray-600 hover:text-gray-800 transition-colors mt-3"
         >
           すべてクリア
         </button>

--- a/src/data/search-data.ts
+++ b/src/data/search-data.ts
@@ -3,7 +3,7 @@ import { PolicyTheme, FilterOption, NetworkNode } from "@/types";
 export const policyThemes: PolicyTheme[] = [
   {
     id: "digital-transformation",
-    title: "DX（デジタル変革）",
+    title: "DX",
     description: "",
     color: "#007aff",
     participants: 0
@@ -38,7 +38,7 @@ export const policyThemes: PolicyTheme[] = [
   },
   {
     id: "adx-new-business",
-    title: "ADX（アジア新事業共創）",
+    title: "ADX",
     description: "",
     color: "#ff6b35",
     participants: 0
@@ -59,7 +59,7 @@ export const policyThemes: PolicyTheme[] = [
   },
   {
     id: "green-growth",
-    title: "グリーン成長戦略",
+    title: "GX",
     description: "",
     color: "#059669",
     participants: 0
@@ -145,7 +145,8 @@ export const sampleNetworkNodes: NetworkNode[] = [
     group: 1,
     x: 400,
     y: 200,
-    connections: ["2", "3", "5"]
+    connections: ["2", "3", "5"],
+    relevanceScore: 0.9
   },
   {
     id: "2", 
@@ -155,7 +156,8 @@ export const sampleNetworkNodes: NetworkNode[] = [
     group: 2,
     x: 250,
     y: 120,
-    connections: ["1", "4", "6"]
+    connections: ["1", "4", "6"],
+    relevanceScore: 0.8
   },
   {
     id: "3",
@@ -165,7 +167,8 @@ export const sampleNetworkNodes: NetworkNode[] = [
     group: 3,
     x: 550,
     y: 120,
-    connections: ["1", "7", "8"]
+    connections: ["1", "7", "8"],
+    relevanceScore: 0.7
   },
   {
     id: "4",
@@ -175,7 +178,8 @@ export const sampleNetworkNodes: NetworkNode[] = [
     group: 4,
     x: 150,
     y: 80,
-    connections: ["2", "9"]
+    connections: ["2", "9"],
+    relevanceScore: 0.6
   },
   {
     id: "5",
@@ -185,7 +189,8 @@ export const sampleNetworkNodes: NetworkNode[] = [
     group: 5,
     x: 350,
     y: 240,
-    connections: ["1", "10"]
+    connections: ["1", "10"],
+    relevanceScore: 0.75
   },
   {
     id: "6",
@@ -195,7 +200,8 @@ export const sampleNetworkNodes: NetworkNode[] = [
     group: 6,
     x: 200,
     y: 200,
-    connections: ["2", "11"]
+    connections: ["2", "11"],
+    relevanceScore: 0.5
   },
   {
     id: "7",
@@ -205,7 +211,8 @@ export const sampleNetworkNodes: NetworkNode[] = [
     group: 7,
     x: 650,
     y: 90,
-    connections: ["3", "12"]
+    connections: ["3", "12"],
+    relevanceScore: 0.4
   },
   {
     id: "8",
@@ -215,7 +222,8 @@ export const sampleNetworkNodes: NetworkNode[] = [
     group: 8,
     x: 600,
     y: 160,
-    connections: ["3", "13"]
+    connections: ["3", "13"],
+    relevanceScore: 0.65
   },
   {
     id: "9",
@@ -225,7 +233,8 @@ export const sampleNetworkNodes: NetworkNode[] = [
     group: 9,
     x: 100,
     y: 60,
-    connections: ["4"]
+    connections: ["4"],
+    relevanceScore: 0.45
   },
   {
     id: "10",
@@ -235,7 +244,8 @@ export const sampleNetworkNodes: NetworkNode[] = [
     group: 10,
     x: 450,
     y: 280,
-    connections: ["5"]
+    connections: ["5"],
+    relevanceScore: 0.55
   },
   {
     id: "11",
@@ -245,7 +255,8 @@ export const sampleNetworkNodes: NetworkNode[] = [
     group: 11,
     x: 150,
     y: 220,
-    connections: ["6"]
+    connections: ["6"],
+    relevanceScore: 0.3
   },
   {
     id: "12",
@@ -255,7 +266,8 @@ export const sampleNetworkNodes: NetworkNode[] = [
     group: 12,
     x: 700,
     y: 80,
-    connections: ["7"]
+    connections: ["7"],
+    relevanceScore: 0.25
   },
   {
     id: "13",
@@ -265,6 +277,7 @@ export const sampleNetworkNodes: NetworkNode[] = [
     group: 13,
     x: 650,
     y: 220,
-    connections: ["8"]
+    connections: ["8"],
+    relevanceScore: 0.85
   }
 ];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -78,8 +78,6 @@ export interface SearchFilters {
   policyThemes: string[]
   industries: string[]
   positions: string[]
-  regions: string[]
-  others: string[]
 }
 
 // ネットワークマップのノード型
@@ -92,6 +90,7 @@ export interface NetworkNode {
   connections: string[]
   x?: number
   y?: number
+  relevanceScore?: number // 0-1の関連度スコア
 }
 
 // 政策テーマ型


### PR DESCRIPTION
- 政策テーマ名称を短縮（DX、ADX、GX等）
- 政策テーマカードを可変横幅に変更
- 政策テーマ選択時カラーを背景色に統一、チェックマーク削除
- 地域フィルター削除、その他をフリーワード検索に変更
- 人脈マップをObsidianライクなスタイルに改善（関連度ベースサイズ、グラデーションノード）
- フィルター選択で外側クリック時の自動クローズ機能追加
- フリーワード検索に検索アイコンとエンターボタン追加
- アイコンサイズ最適化（15px/12px）
- 人脈マップ初期表示テキストを太字化
- LoginFormセキュリティ修正（環境変数化）
- NetworkMapエラー修正（削除されたフィルタープロパティ対応）