### PR TITLE
feat: コメント数取得API連携と日付フォーマット改善

### DIFF
--- a/src/components/blocks/ExpertArticleListPage.tsx
+++ b/src/components/blocks/ExpertArticleListPage.tsx
@@ -5,11 +5,45 @@ import { useRouter } from "next/navigation";
 import { ExpertPolicyTheme, ExpertArticle, ExpertPageState, ExpertFilterState, ExpertOverlayState, ExpertComment, CommentSortOption, PolicyProposal } from "@/types";
 import { policyThemes, getArticlesByTheme, searchArticles, getArticleComments, sortComments } from "@/data/expert-articles-data";
 import BackgroundEllipses from "@/components/blocks/BackgroundEllipses";
+import { CommentCount } from "@/components/ui/comment-count";
 import { getPolicyProposals } from "@/lib/expert-api";
 
 // 画像アセット
 const imgSubTitleIcon = "http://localhost:3845/assets/97cd832355f773e22c5e4fede61842ffbe828a02.svg";
 const imgUserIcon = "http://localhost:3845/assets/0046f2f481d47419a2b5046e941c98fae542e480.svg";
+
+// 日付フォーマット関数
+const formatDate = (dateString: string): string => {
+  try {
+    const date = new Date(dateString);
+    const now = new Date();
+    const diffTime = Math.abs(now.getTime() - date.getTime());
+    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+    
+    if (diffDays === 1) {
+      return "昨日";
+    } else if (diffDays <= 7) {
+      return `${diffDays}日前`;
+    } else if (diffDays <= 30) {
+      const weeks = Math.floor(diffDays / 7);
+      return `${weeks}週間前`;
+    } else if (diffDays <= 365) {
+      const months = Math.floor(diffDays / 30);
+      return `${months}ヶ月前`;
+    } else {
+      return date.toLocaleDateString('ja-JP', { 
+        year: 'numeric', 
+        month: 'long', 
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit'
+      });
+    }
+  } catch (error) {
+    // パースに失敗した場合は元の文字列を返す
+    return dateString;
+  }
+};
 
 // データ変換関数
 const convertPolicyProposalToExpertArticle = (proposal: PolicyProposal): ExpertArticle => ({
@@ -18,7 +52,7 @@ const convertPolicyProposalToExpertArticle = (proposal: PolicyProposal): ExpertA
   summary: proposal.body.substring(0, 100) + "...", // 最初の100文字をサマリーとして使用
   content: proposal.body,
   department: "中小企業庁 地域産業支援課", // 仮の値
-  publishedAt: proposal.published_at || proposal.created_at,
+  publishedAt: formatDate(proposal.published_at || proposal.created_at),
   commentCount: 0, // 後で計算
   themeId: proposal.policy_tags && proposal.policy_tags.length > 0 
     ? proposal.policy_tags[0].id.toString() 
@@ -135,15 +169,11 @@ const ArticleCard = ({
       </div>
       
       <div className="absolute right-4 top-1/2 transform -translate-y-1/2 flex items-center gap-2">
-        <div className="flex items-center justify-center w-4 h-4">
-          <svg className="w-3 h-3 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-          </svg>
-        </div>
-        <div className="flex flex-col items-center">
-          <span className="text-[10px] text-gray-500 font-medium">コメント</span>
-          <span className="text-[12px] text-gray-700 font-bold">({article.commentCount})</span>
-        </div>
+        <CommentCount 
+          policyProposalId={article.id}
+          className="text-[12px] text-gray-700 font-bold"
+          showIcon={true}
+        />
       </div>
       
       <div className="absolute flex h-[3.983px] items-center justify-center left-0 right-0 top-[85px]">
@@ -302,7 +332,13 @@ const ArticleOverlay = ({
             <div className="flex items-center gap-4 text-sm text-gray-600 mb-4">
               <span>{article.department}</span>
               <span>{article.publishedAt}</span>
-              <span>コメント: {article.commentCount}件</span>
+              <span>
+                コメント: <CommentCount 
+                  policyProposalId={article.id}
+                  className="text-gray-600"
+                  showIcon={false}
+                />
+              </span>
             </div>
             
             {/* 記事本文 */}

--- a/src/components/blocks/PolicyCommentsPage.tsx
+++ b/src/components/blocks/PolicyCommentsPage.tsx
@@ -6,6 +6,7 @@ import { PolicySubmission, PolicyComment } from '@/types';
 import { samplePolicySubmissions, getCommentsByPolicyId } from '@/data/policy-data';
 import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { CommentCount } from '@/components/ui/comment-count';
 
 // ステータスに応じた色とラベルを取得（現在は使用していないが将来の拡張用）
 const _getStatusInfo = (status: PolicySubmission['status']) => {
@@ -313,7 +314,13 @@ const PolicySubmissionCard = ({
       </div>
       
       <div className="flex justify-between items-center mt-2 text-sm text-gray-500">
-        <span>コメント: {policy.commentCount}件</span>
+        <span>
+          コメント: <CommentCount 
+            policyProposalId={policy.id}
+            className="text-gray-500"
+            showIcon={false}
+          />
+        </span>
         {policy.attachedFiles && policy.attachedFiles.length > 0 && (
           <span>添付ファイル: {policy.attachedFiles.length}件</span>
         )}

--- a/src/components/blocks/figma/TopPage.tsx
+++ b/src/components/blocks/figma/TopPage.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useTopPageNavigation } from "@/hooks/useTopPageNavigation";
+import { getCommentCount } from "@/lib/expert-api";
+import { useState, useEffect } from "react";
 
 const imgVector = "http://localhost:3845/assets/53106efe68def3412993b290c8c5de68bee352e7.svg";
 const imgBackground = "http://localhost:3845/assets/083b7eb8e500a0b2b2331d38e424932148783b69.svg";
@@ -46,6 +48,23 @@ export default function TopPage() {
     handleSubmitPolicy,
     handleCheckOpinions,
   } = useTopPageNavigation();
+
+  const [totalCommentCount, setTotalCommentCount] = useState(0);
+
+  useEffect(() => {
+    const fetchCommentCount = async () => {
+      try {
+        // 仮のpolicy_proposal_idを使用（実際の実装では適切なIDを使用）
+        const data = await getCommentCount("sample-policy-001");
+        setTotalCommentCount(data.comment_count);
+      } catch (error) {
+        console.error("コメント数取得エラー:", error);
+        setTotalCommentCount(0);
+      }
+    };
+
+    fetchCommentCount();
+  }, []);
 
   return (
     <div
@@ -315,9 +334,18 @@ export default function TopPage() {
                 <p className="adjustLetterSpacing block mb-0">
                   有識者のリアルなコメント・提案を一覧で確認。
                 </p>
-                <p className="adjustLetterSpacing block">
+                <p className="adjustLetterSpacing block mb-2">
                   政策案を磨きながら、次に繋がる人脈と出会えます。
                 </p>
+                {/* コメント数表示 */}
+                <div className="flex items-center justify-center gap-2 mt-4">
+                  <div className="flex items-center justify-center w-6 h-6">
+                    <svg className="w-4 h-4 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+                    </svg>
+                  </div>
+                  <span className="text-white text-lg font-bold">コメント ({totalCommentCount})</span>
+                </div>
               </div>
             </div>
           </div>

--- a/src/components/ui/comment-count.tsx
+++ b/src/components/ui/comment-count.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import React, { useState, useEffect } from 'react';
+import { getCommentCount, CommentCountResponse } from '@/lib/expert-api';
+
+interface CommentCountProps {
+  policyProposalId: string;
+  className?: string;
+  showIcon?: boolean;
+}
+
+export const CommentCount: React.FC<CommentCountProps> = ({ 
+  policyProposalId, 
+  className = "",
+  showIcon = true
+}) => {
+  const [commentCount, setCommentCount] = useState<number>(0);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchCommentCount = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        
+        const data: CommentCountResponse = await getCommentCount(policyProposalId);
+        setCommentCount(data.comment_count);
+      } catch (err) {
+        console.error('コメント数取得エラー:', err);
+        setError('コメント数の取得に失敗しました');
+        setCommentCount(0);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (policyProposalId) {
+      fetchCommentCount();
+    }
+  }, [policyProposalId]);
+
+  if (loading) {
+    return (
+      <span className={`${className} inline-flex items-center text-gray-500`}>
+        {showIcon && (
+          <svg className="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+          </svg>
+        )}
+        読み込み中...
+      </span>
+    );
+  }
+
+  if (error) {
+    return (
+      <span className={`${className} text-red-500 cursor-help`} title={error}>
+        {showIcon && (
+          <svg className="inline w-4 h-4 mr-1" fill="currentColor" viewBox="0 0 20 20">
+            <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
+          </svg>
+        )}
+        エラー
+      </span>
+    );
+  }
+
+  return (
+    <span className={`${className} inline-flex items-center`}>
+      {showIcon && (
+        <svg className="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+        </svg>
+      )}
+      {commentCount} コメント
+    </span>
+  );
+};

--- a/src/data/policy-data.ts
+++ b/src/data/policy-data.ts
@@ -111,3 +111,22 @@ export const getPolicySubmissionById = (id: string): PolicySubmission | undefine
 export const getCommentsByPolicyId = (policyId: string): PolicyComment[] => {
   return samplePolicyComments.filter(comment => comment.policyId === policyId);
 };
+
+// コメント数を取得する関数
+export const getTotalCommentCount = (): number => {
+  return samplePolicySubmissions.reduce((total, policy) => total + policy.commentCount, 0);
+};
+
+// 最新のコメント数を取得する関数
+export const getRecentCommentCount = (days: number = 7): number => {
+  const cutoffDate = new Date();
+  cutoffDate.setDate(cutoffDate.getDate() - days);
+  
+  return samplePolicySubmissions.reduce((total, policy) => {
+    const policyDate = new Date(policy.submittedAt.replace('年', '/').replace('月', '/').replace('日', ''));
+    if (policyDate >= cutoffDate) {
+      return total + policy.commentCount;
+    }
+    return total;
+  }, 0);
+};

--- a/src/lib/expert-api.ts
+++ b/src/lib/expert-api.ts
@@ -17,6 +17,12 @@ export interface PolicyCommentResponse {
   message: string;
 }
 
+// コメント数取得のレスポンス型
+export interface CommentCountResponse {
+  policy_proposal_id: string;
+  comment_count: number;
+}
+
 // 政策提案作成（添付ファイル付き）のリクエスト型
 export interface PolicyProposalWithAttachmentsRequest {
   title: string;
@@ -92,6 +98,14 @@ export async function likeComment(commentId: string): Promise<{ success: boolean
 export async function unlikeComment(commentId: string): Promise<{ success: boolean; likeCount: number }> {
   return apiFetch(`/api/policy-proposal-comments/${commentId}/unlike`, {
     method: "DELETE",
+    auth: true,
+  });
+}
+
+// コメント数取得API
+export async function getCommentCount(policyProposalId: string): Promise<CommentCountResponse> {
+  return apiFetch(`/api/policy-proposal-comments/policy-proposals/${policyProposalId}/comment-count`, {
+    method: "GET",
     auth: true,
   });
 }


### PR DESCRIPTION
## 概要
PolicyProposalComments数取得APIとフロントエンドを連携し、コメント数表示機能を実装しました。

## 主な変更点
- PolicyProposalComments数取得APIの実装
- CommentCountコンポーネントの作成
- 既存ページでのコメント数表示を実際のAPIから取得に変更
- 日付表示を読みやすい日本語形式に改善（相対時間表示）
- エラーハンドリングとローディング状態の実装

## 動作確認
- [x] コメント数の正常取得
- [x] 日付フォーマットの改善
- [x] エラーハンドリング
- [x] ローディング状態の表示