### PR TITLE
feat: コメント投稿者の実際の名前を表示するように修正

### DIFF
--- a/src/components/blocks/ExpertPostDetailPage.tsx
+++ b/src/components/blocks/ExpertPostDetailPage.tsx
@@ -61,7 +61,7 @@ const convertPolicyCommentToExpertComment = (comment: PolicyProposalComment): Ex
   id: comment.id,
   author: {
     id: comment.author_id,
-    name: `ユーザー${comment.author_id.slice(-4)}`, // 仮の名前
+    name: comment.author_name || `ユーザー${comment.author_id.slice(-4)}`, // バックエンドから取得した名前を使用、フォールバックとして仮の名前
     role: comment.author_type === "contributor" ? "エキスパート" : comment.author_type,
     company: "会社名", // 仮の値
     badges: [

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -283,6 +283,7 @@ export interface PolicyProposalComment {
   policy_proposal_id: string;
   author_type: "admin" | "staff" | "contributor" | "viewer";
   author_id: string;
+  author_name: string | null; // 投稿者の実際の名前（姓 + 名）
   comment_text: string;
   parent_comment_id: string | null;
   evaluation: number | null; // 1-5


### PR DESCRIPTION
## 概要
コメント投稿者の名前が「ユーザーXXXX」という仮の表示になっていた問題を修正し、バックエンドから取得した実際のユーザー名を表示するようにしました。

## 変更内容
- `PolicyProposalComment`型に`author_name: string | null`フィールドを追加
- `convertPolicyCommentToExpertComment`関数でバックエンドから取得した名前を優先使用
- フォールバックとして従来の仮の名前生成ロジックを維持

## 技術的な変更
### 型定義の更新 (`src/types/index.ts`)
```typescript
export interface PolicyProposalComment {
  // ... 既存フィールド
  author_name: string | null; // 投稿者の実際の名前（姓 + 名）
  // ... 既存フィールド
}
```

### コメント変換ロジックの改善 (`src/components/blocks/ExpertPostDetailPage.tsx`)
```typescript
name: comment.author_name || `ユーザー${comment.author_id.slice(-4)}`
```

## 動作確認
- テスト用政策提案ID: `11111111-2222-3333-4444-555555555555`
- 期待される表示:
  - `"テスト ひろし"` (staff)
  - `"鈴木 一郎"` (contributor)
  - `"てすと たろう"` (staff)

## 関連Issue
- コメント投稿者の名前表示が仮の名前になっている問題

## テスト項目
- [ ] 各種ユーザータイプ（staff, admin, contributor）での名前表示
- [ ] `author_name`が`null`の場合のフォールバック処理
- [ ] 既存のコメント表示に影響がないことの確認