### PR TITLE
feat: コメント情報をハードコーディングからAPI取得に変更

### DIFF
--- a/src/lib/expert-api.ts
+++ b/src/lib/expert-api.ts
@@ -145,3 +145,52 @@ export async function getPolicyProposalComments(id: string, limit = 50, offset =
     auth: true,
   });
 }
+
+// ユーザー情報取得API
+export async function getUserInfo(userId: string): Promise<{
+  id: string;
+  name: string;
+  role: string;
+  company: string;
+  department?: string;
+  title?: string;
+  badges: Array<{
+    type: string;
+    label: string;
+    color: string;
+    description: string;
+  }>;
+  expertiseLevel: string;
+}> {
+  return apiFetch(`/api/users/${userId}`, {
+    method: "GET",
+    auth: true,
+  });
+}
+
+// 複数ユーザーの情報を一括取得するAPI
+export async function getUsersInfo(userIds: string[]): Promise<{
+  [userId: string]: {
+    id: string;
+    name: string;
+    role: string;
+    company: string;
+    department?: string;
+    title?: string;
+    badges: Array<{
+      type: string;
+      label: string;
+      color: string;
+      description: string;
+    }>;
+    expertiseLevel: string;
+  };
+}> {
+  const queryParams = new URLSearchParams();
+  userIds.forEach(id => queryParams.append('user_ids', id));
+  
+  return apiFetch(`/api/users/batch?${queryParams}`, {
+    method: "GET",
+    auth: true,
+  });
+}


### PR DESCRIPTION
## 概要
コメントに表示されるユーザー情報（名前、役職、会社名、バッジなど）をハードコーディングされたデータからAPIエンドポイントからの動的取得に変更しました。

## 変更内容

### 🔧 修正したファイル
- `src/components/blocks/ExpertPostDetailPage.tsx`
- `src/components/blocks/ExpertArticleListPage.tsx`
- `src/lib/expert-api.ts`

### ✨ 新機能
- ユーザー情報取得API関数の追加
- 複数ユーザー情報の一括取得機能
- コメント取得処理のAPI化

### 🚀 改善点
- **パフォーマンス向上**: ユーザー情報を一括取得することでAPI呼び出し回数を削減
- **エラーハンドリング**: API取得失敗時のフォールバック処理を実装
- **型安全性**: TypeScriptの型チェックを強化
- **ユーザー体験**: ローディング状態の表示を追加

### 🔄 変更詳細
1. **ExpertPostDetailPage.tsx**
   - コメント取得処理を`getPolicyProposalComments` APIを使用するように変更
   - ユーザー情報を一括取得する機能を追加
   - 新しいコメント投稿時のユーザー情報もAPIから取得

2. **ExpertArticleListPage.tsx**
   - オーバーレイ表示時のコメント取得処理をAPI化
   - 非同期でのコメント取得処理を実装
   - ローディング状態とエラーハンドリングを追加

3. **expert-api.ts**
   - `getUserInfo`: 単一ユーザー情報取得API関数を追加
   - `getUsersInfo`: 複数ユーザー情報一括取得API関数を追加

## テスト
- [ ] コメント一覧の表示確認
- [ ] ユーザー情報の正しい表示確認
- [ ] エラー時のフォールバック処理確認
- [ ] ローディング状態の表示確認

## 関連Issue
- コメント表示のハードコーディング問題の解決