### PR TITLE
fix: SVGファイルを直接インポート方式に変更して本番環境での表示を修正

### DIFF
--- a/src/components/blocks/PolicySubmissionPage.tsx
+++ b/src/components/blocks/PolicySubmissionPage.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useRef } from 'react';
 import { useRouter } from "next/navigation";
+import fileSvg from "/public/file.svg";
 // import { PolicyThemeSelector } from "@/components/ui/policy-theme-selector";
 
 interface PolicyFormData {
@@ -164,8 +165,7 @@ export function PolicySubmissionPage() {
 
   // Figma variables and assets
   const COLOR_PRIMARY = "#007aff"; // Miscellaneous/Floating Tab - Text Selected
-  import fileSvg from "/public/file.svg";
-const IMG_OCTICON_FILE_16 = fileSvg;
+  const IMG_OCTICON_FILE_16 = fileSvg;
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const handleThemeToggle = (_themeId: string) => {


### PR DESCRIPTION
## 概要
本番環境でSVGファイルが表示されない問題を解決するため、SVGファイルの読み込み方法を直接インポート方式に変更しました。

## 問題
- ローカル環境ではSVGが正常に表示されるが、本番環境（デプロイ後）でSVGが表示されない
- `public`ディレクトリのSVGファイルが本番環境で正しく配信されていない

## 解決策
SVGファイルの読み込み方法を直接インポート方式に変更

## 修正したファイル
- `src/components/blocks/figma/TopPage.tsx`
- `src/components/blocks/SearchPage.tsx`
- `src/components/blocks/ExpertArticleListPage.tsx`
- `src/components/blocks/PolicySubmissionPage.tsx`
- `src/components/blocks/PolicyCommentsPage.tsx.backup`

## 確認済み
- ✅ ローカルでの動作確認済み
- ✅ ビルド成功確認済み
- ✅ 型チェック通過済み