### PR TITLE
Fix SVG import paths to resolve build error

### DIFF
--- a/src/components/blocks/ExpertArticleListPage.tsx
+++ b/src/components/blocks/ExpertArticleListPage.tsx
@@ -9,8 +9,8 @@ import { CommentCount } from "@/components/ui/comment-count";
 import { getPolicyProposals, getPolicyProposalComments, getUsersInfo } from "@/lib/expert-api";
 
 // 画像アセット
-import fileSvg from "/public/file.svg";
-import globeSvg from "/public/globe.svg";
+const fileSvg = "/file.svg";
+const globeSvg = "/globe.svg";
 const imgSubTitleIcon = fileSvg;
 const imgUserIcon = globeSvg;
 

--- a/src/components/blocks/PolicyCommentsPage.tsx.backup
+++ b/src/components/blocks/PolicyCommentsPage.tsx.backup
@@ -6,7 +6,7 @@ import { PolicySubmission, PolicyComment, CommentAnalysis } from '@/types';
 import { samplePolicySubmissions, getCommentsByPolicyId } from '@/data/policy-data';
 import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import commentsViewBgSvg from "/public/comments-view-bg.svg";
+const commentsViewBgSvg = "/comments-view-bg.svg";
 
 // ステータスに応じた色とラベルを取得（現在は使用していないが将来の拡張用）
 const _getStatusInfo = (status: PolicySubmission['status']) => {

--- a/src/components/blocks/PolicySubmissionPage.tsx
+++ b/src/components/blocks/PolicySubmissionPage.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useRef } from 'react';
 import { useRouter } from "next/navigation";
-import fileSvg from "/public/file.svg";
+const fileSvg = "/file.svg";
 // import { PolicyThemeSelector } from "@/components/ui/policy-theme-selector";
 
 interface PolicyFormData {

--- a/src/components/blocks/figma/TopPage.tsx
+++ b/src/components/blocks/figma/TopPage.tsx
@@ -5,10 +5,10 @@ import { getCommentCount } from "@/lib/expert-api";
 import { useState, useEffect } from "react";
 
 // SVGファイルを直接インポート
-import fileSvg from "/public/file.svg";
-import networkSearchBgSvg from "/public/network-search-bg.svg";
-import policySubmitBgSvg from "/public/policy-submit-bg.svg";
-import commentsViewBgSvg from "/public/comments-view-bg.svg";
+const fileSvg = "/file.svg";
+const networkSearchBgSvg = "/network-search-bg.svg";
+const policySubmitBgSvg = "/policy-submit-bg.svg";
+const commentsViewBgSvg = "/comments-view-bg.svg";
 
 // SVGファイルのパスを修正
 const imgVector = fileSvg;


### PR DESCRIPTION
  ## 修正内容
  - SVGファイルのインポートパスを修正
  - `/public/file.svg` → `/file.svg` に変更
  - ビルドエラーを解決
  
  ## 修正ファイル
  - src/components/blocks/ExpertArticleListPage.tsx
  - src/components/blocks/PolicySubmissionPage.tsx
  - src/components/blocks/figma/TopPage.tsx
  - src/components/blocks/PolicyCommentsPage.tsx.backup