### PR TITLE
expert/articlesページのUI改善 - 政策テーマボタン配置調整、読み込み表示モダン化、背景統一

### DIFF
--- a/src/components/blocks/ExpertArticleListPage.tsx
+++ b/src/components/blocks/ExpertArticleListPage.tsx
@@ -8,11 +8,7 @@ import BackgroundEllipses from "@/components/blocks/BackgroundEllipses";
 import { CommentCount } from "@/components/ui/comment-count";
 import { getPolicyProposals, getPolicyProposalComments, getUsersInfo } from "@/lib/expert-api";
 
-// 画像アセット
-const fileSvg = "/file.svg";
-const globeSvg = "/globe.svg";
-const imgSubTitleIcon = fileSvg;
-const imgUserIcon = globeSvg;
+
 
 // 日付フォーマット関数
 const formatDate = (dateString: string): string => {
@@ -70,29 +66,29 @@ const PolicyThemeSelector = ({
   onThemeSelect: (themeId: string) => void;
 }) => {
   return (
-    <div className="absolute contents left-[74.99px] top-[123.83px]">
+    <div className="absolute contents left-[65px] top-[123.83px]">
       {themes.map((theme, index) => {
-        // Figmaのデザインに合わせた正確な位置計算
+        // メインエリアのカードと同じ位置に合わせた位置計算
         const positions = [
-          { left: 74.99, top: 123.83 }, // 経済産業省
-          { left: 74.99, top: 163.00 }, // 再生可能エネルギー
-          { left: 238.77, top: 123.83 }, // DX（デジタル変革）
-          { left: 238.77, top: 163.00 }, // 水素社会
-          { left: 402.56, top: 123.83 }, // 産業構造転換
-          { left: 402.56, top: 163.00 }, // 資源外交
-          { left: 566.35, top: 123.83 }, // スタートアップ・中小企業支援
-          { left: 566.35, top: 163.00 }, // グリーン成長戦略
-          { left: 730.13, top: 124.33 }, // 通商戦略
-          { left: 730.13, top: 163.00 }, // デジタル政策
-          { left: 893.92, top: 124.33 }, // 経済安全保障
-          { left: 893.92, top: 163.00 }, // 人材政策
-          { left: 1057.7, top: 124.33 }, // 経済連携
-          { left: 1057.7, top: 163.00 }, // 産学連携
-          { left: 1221.49, top: 124.33 }, // ADX（アジア新産業共創）
-          { left: 1221.49, top: 163.00 }, // 地域政策
+          { left: 65, top: 123.83 }, // 経済産業省
+          { left: 65, top: 163.00 }, // 再生可能エネルギー
+          { left: 228.78, top: 123.83 }, // DX（デジタル変革）
+          { left: 228.78, top: 163.00 }, // 水素社会
+          { left: 392.57, top: 123.83 }, // 産業構造転換
+          { left: 392.57, top: 163.00 }, // 資源外交
+          { left: 556.36, top: 123.83 }, // スタートアップ・中小企業支援
+          { left: 556.36, top: 163.00 }, // グリーン成長戦略
+          { left: 720.14, top: 124.33 }, // 通商戦略
+          { left: 720.14, top: 163.00 }, // デジタル政策
+          { left: 883.93, top: 124.33 }, // 経済安全保障
+          { left: 883.93, top: 163.00 }, // 人材政策
+          { left: 1047.71, top: 124.33 }, // 経済連携
+          { left: 1047.71, top: 163.00 }, // 産学連携
+          { left: 1211.5, top: 124.33 }, // ADX（アジア新産業共創）
+          { left: 1211.5, top: 163.00 }, // 地域政策
         ];
         
-        const position = positions[index] || { left: 74.99, top: 140.83 };
+        const position = positions[index] || { left: 65, top: 140.83 };
         
         return (
           <div
@@ -651,7 +647,19 @@ export default function ExpertArticleListPage() {
   return (
     <div className="bg-[#939393] relative size-full h-screen overflow-hidden">
       {/* 背景グラデーション */}
-      <div className="absolute bg-gradient-to-t from-[#b4d9d6] h-[1024px] left-1/2 to-[#58aadb] top-1/2 translate-x-[-50%] translate-y-[-50%] w-[1440px]" />
+      <div className="absolute bg-gradient-to-t from-[#7bc8e8] via-[#58aadb] to-[#2d8cd9] h-[1024px] left-1/2 top-1/2 translate-x-[-50%] translate-y-[-50%] w-[1440px]" />
+      
+      {/* テクスチャ効果 */}
+      <div className="absolute inset-0 opacity-20 pointer-events-none" style={{
+        backgroundImage: `url("data:image/svg+xml,${encodeURIComponent(`
+          <svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+            <filter id="noiseFilter">
+              <feTurbulence type="fractalNoise" baseFrequency="1.5" numOctaves="4" stitchTiles="stitch"/>
+            </filter>
+            <rect width="100%" height="100%" filter="url(#noiseFilter)"/>
+          </svg>
+        `)}")`
+      }}></div>
       
       {/* 背景装飾 */}
       <BackgroundEllipses scale={0.8} />
@@ -672,9 +680,6 @@ export default function ExpertArticleListPage() {
         <div className="absolute inset-[13.58%_6.81%_14.98%_81.12%]">
           <div className="absolute bottom-[2.5%] font-['Montserrat:SemiBold',_'Noto_Sans_JP:Bold',_sans-serif] font-semibold leading-[0] left-0 right-[20%] text-[#ffffff] text-[12.62px] text-left text-nowrap top-[12.5%] tracking-[1.5144px]">
             <p className="adjustLetterSpacing block leading-[1.4] whitespace-pre">テックゼロ太郎さん</p>
-          </div>
-          <div className="absolute inset-[12.5%_4.83%_10%_85.67%]">
-            <img alt="ユーザーアイコン" className="block max-w-none size-full" src={imgUserIcon} />
           </div>
         </div>
         
@@ -724,11 +729,8 @@ export default function ExpertArticleListPage() {
       
       {/* サブタイトル */}
       <div className="absolute h-[25px] left-[77.48px] top-[85px] w-[563.542px]">
-        <div className="absolute flex flex-col font-['Noto_Sans_JP:Bold',_sans-serif] font-bold justify-center leading-[0] left-[27.38px] text-[#ffffff] text-[11.948px] text-left top-[12.5px] tracking-[2.4842px] translate-y-[-50%] w-[536.163px]">
+        <div className="absolute flex flex-col font-['Noto_Sans_JP:Bold',_sans-serif] font-bold justify-center leading-[0] left-0 text-[#ffffff] text-[11.948px] text-left top-[12.5px] tracking-[2.4842px] translate-y-[-50%] w-[563.542px]">
           <p className="adjustLetterSpacing block leading-[24.67px]">政策テーマを選ぶ</p>
-        </div>
-        <div className="absolute left-0 size-[21.407px] top-[1px]">
-          <img alt="サブタイトルアイコン" className="block max-w-none size-full" src={imgSubTitleIcon} />
         </div>
       </div>
       
@@ -750,8 +752,15 @@ export default function ExpertArticleListPage() {
       <div className="absolute h-[500px] left-[65px] top-[249px] w-[1304px] z-40">
         <div className="absolute bg-[#ffffff] h-[500px] left-0 rounded-[11.759px] top-0 w-[1304px] overflow-y-auto overflow-x-hidden scrollbar-thin scrollbar-thumb-gray-300 scrollbar-track-gray-100">
           {pageState === "loading" && (
-            <div className="flex items-center justify-center h-full">
-              <div className="text-gray-500">読み込み中...</div>
+            <div className="flex flex-col items-center justify-center h-full">
+              <div className="text-gray-500 text-lg mb-4 font-medium">Loading...</div>
+              
+              {/* アニメーションするローディングドット */}
+              <div className="flex space-x-2">
+                <div className="w-3 h-3 bg-gray-400 rounded-full animate-bounce" style={{ animationDelay: '0ms' }}></div>
+                <div className="w-3 h-3 bg-gray-400 rounded-full animate-bounce" style={{ animationDelay: '150ms' }}></div>
+                <div className="w-3 h-3 bg-gray-400 rounded-full animate-bounce" style={{ animationDelay: '300ms' }}></div>
+              </div>
             </div>
           )}
           
@@ -764,7 +773,14 @@ export default function ExpertArticleListPage() {
           <div className="p-6 pb-8">
             {pageState === "loading" && (
               <div className="text-center py-8">
-                <p className="text-gray-500">読み込み中...</p>
+                <div className="text-gray-500 text-lg mb-4 font-medium">Loading...</div>
+                
+                {/* アニメーションするローディングドット */}
+                <div className="flex justify-center space-x-2">
+                  <div className="w-3 h-3 bg-gray-400 rounded-full animate-bounce" style={{ animationDelay: '0ms' }}></div>
+                  <div className="w-3 h-3 bg-gray-400 rounded-full animate-bounce" style={{ animationDelay: '150ms' }}></div>
+                  <div className="w-3 h-3 bg-gray-400 rounded-full animate-bounce" style={{ animationDelay: '300ms' }}></div>
+                </div>
               </div>
             )}
             
@@ -777,8 +793,24 @@ export default function ExpertArticleListPage() {
             {pageState !== "loading" && pageState !== "error" && (
               <>
                 {filteredArticles.length === 0 ? (
-                  <div className="text-center py-8">
-                    <p className="text-gray-500">記事が見つかりませんでした</p>
+                  <div className="text-center py-12">
+                    {/* メインテキスト */}
+                    <h3 className="text-lg font-semibold text-[#58aadb] mb-2">記事がまだありません</h3>
+                    
+                    {/* サブテキスト */}
+                    <p className="text-gray-500 text-sm max-w-md mx-auto leading-relaxed">
+                      選択されたテーマに関連する記事がまだ投稿されていません。<br />
+                      他のテーマを選択するか、しばらくお待ちください。
+                    </p>
+                    
+                    {/* 装飾的な要素 */}
+                    <div className="mt-6 flex justify-center">
+                      <div className="flex space-x-1">
+                        <div className="w-2 h-2 bg-gray-200 rounded-full"></div>
+                        <div className="w-2 h-2 bg-gray-300 rounded-full"></div>
+                        <div className="w-2 h-2 bg-gray-200 rounded-full"></div>
+                      </div>
+                    </div>
                   </div>
                 ) : (
                   filteredArticles.map((article, _index) => (

--- a/src/components/blocks/ExpertPostDetailPage.tsx
+++ b/src/components/blocks/ExpertPostDetailPage.tsx
@@ -691,8 +691,38 @@ export default function ExpertPostDetailPage({ articleId }: { articleId: string 
   if (isLoading) {
     return (
       <div className="bg-[#939393] relative size-full h-screen overflow-hidden">
-        <div className="flex items-center justify-center h-full">
-          <div className="text-white text-lg">読み込み中...</div>
+        {/* 背景グラデーション */}
+        <div className="absolute bg-gradient-to-t from-[#7bc8e8] via-[#58aadb] to-[#2d8cd9] h-[1024px] left-1/2 top-1/2 translate-x-[-50%] translate-y-[-50%] w-[1440px]" />
+        
+        {/* ノイズテクスチャ効果 */}
+        <div 
+          className="absolute inset-0 opacity-20"
+          style={{
+            backgroundImage: `url("data:image/svg+xml,${encodeURIComponent(`
+              <svg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'>
+                <filter id='noiseFilter'>
+                  <feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='1' stitchTiles='stitch'/>
+                </filter>
+                <rect width='100%' height='100%' filter='url(%23noiseFilter)' opacity='0.4'/>
+              </svg>
+            `)}")`,
+          }}
+        />
+        
+        <div className="flex flex-col items-center justify-center h-full relative z-10">
+          <div className="text-white text-lg mb-6">読み込み中...</div>
+          
+          {/* ローディングバー */}
+          <div className="w-64 bg-white/20 rounded-full h-2 overflow-hidden">
+            <div className="h-full bg-white rounded-full animate-pulse"></div>
+          </div>
+          
+          {/* アニメーションするローディングドット */}
+          <div className="flex space-x-1 mt-4">
+            <div className="w-2 h-2 bg-white rounded-full animate-bounce" style={{ animationDelay: '0ms' }}></div>
+            <div className="w-2 h-2 bg-white rounded-full animate-bounce" style={{ animationDelay: '150ms' }}></div>
+            <div className="w-2 h-2 bg-white rounded-full animate-bounce" style={{ animationDelay: '300ms' }}></div>
+          </div>
         </div>
       </div>
     );
@@ -711,7 +741,22 @@ export default function ExpertPostDetailPage({ articleId }: { articleId: string 
   return (
     <div className="bg-[#939393] relative size-full h-screen overflow-hidden">
       {/* 背景グラデーション */}
-      <div className="absolute bg-gradient-to-t from-[#b4d9d6] h-[400px] left-1/2 to-[#58aadb] top-0 translate-x-[-50%] w-[1440px]" />
+      <div className="absolute bg-gradient-to-t from-[#7bc8e8] via-[#58aadb] to-[#2d8cd9] h-[1024px] left-1/2 top-1/2 translate-x-[-50%] translate-y-[-50%] w-[1440px]" />
+      
+      {/* ノイズテクスチャ効果 */}
+      <div 
+        className="absolute inset-0 opacity-20"
+        style={{
+          backgroundImage: `url("data:image/svg+xml,${encodeURIComponent(`
+            <svg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'>
+              <filter id='noiseFilter'>
+                <feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='1' stitchTiles='stitch'/>
+              </filter>
+              <rect width='100%' height='100%' filter='url(%23noiseFilter)' opacity='0.4'/>
+            </svg>
+          `)}")`,
+        }}
+      />
       
       {/* 背景装飾 */}
       <BackgroundEllipses scale={0.8} />


### PR DESCRIPTION
## �� Expert ArticlesページのUI改善

### 📋 変更内容

#### 1. 政策テーマボタンの配置調整
- **変更前**: `left-[74.99px]` から開始
- **変更後**: `left-[65px]` から開始（メインエリアのカードと同じ位置）
- すべてのボタンの位置を9.99px左にずらして調整

#### 2. アイコンの削除
- **政策テーマを選ぶの前のアイコン**（サブタイトルアイコン）を削除
- **テックゼロ太郎さんの後ろのアイコン**（ユーザーアイコン）を削除
- 未使用の変数も削除してクリーンアップ

#### 3. 記事一覧の読み込み表示をモダン化
- **変更前**: シンプルな「読み込み中...」テキスト
- **変更後**: 
  - 「Loading...」の文字
  - アニメーションする3つのドット（順番にバウンス）
  - より視覚的に分かりやすいローディング表示

#### 4. 記事がない場合の表示をモダン化
- **変更前**: シンプルな「記事が見つかりませんでした」
- **変更後**:
  - アイコン削除
  - 「記事がまだありません」を青色（`#58aadb`）で表示
  - 説明文と装飾ドットでモダンな印象

#### 5. 記事詳細ページの背景統一
- **変更前**: 古いグラデーション（`from-[#b4d9d6] to-[#58aadb]`）
- **変更後**: 新しいグラデーション（`from-[#7bc8e8] via-[#58aadb] to-[#2d8cd9]`）
- ノイズテクスチャ効果を追加
- `/expert/articles`と同じ美しい背景デザインに統一

### �� 改善効果

1. **レイアウト統一**: 政策テーマボタンとメインエリアのカードが同じ位置に揃う
2. **視覚的改善**: モダンなローディング表示と空状態表示
3. **デザイン統一**: 全ページで一貫した美しい背景デザイン
4. **UX向上**: より分かりやすく魅力的なユーザーインターフェース

### �� 技術的変更

- **ファイル**: `src/components/blocks/ExpertArticleListPage.tsx`
- **ファイル**: `src/components/blocks/ExpertPostDetailPage.tsx`
- **変更行数**: 117行追加、40行削除

### ✅ 確認済み

- [x] コンフリクトなし
- [x] ローカルビルド成功
- [x] エラーなし
- [x] 警告のみ（既存のもの）