### PR TITLE
feat: 人物プロフィールページの背景統一とMETI Picksタイトルのダッシュボード遷移機能追加

### DIFF
--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -7,6 +7,7 @@ import { ProfileHeader } from "@/components/profile/ProfileHeader";
 import { ProfileNetworkRoutes } from "@/components/ui/profile-network-routes";
 import { ExpertInsightsOut, MeetingOverviewOut, PolicyProposalCommentOut, NetworkMapResponseDTO, stanceToLabel } from "@/types";
 import { apiFetch } from "@/lib/apiClient";
+import BackgroundEllipses from "@/components/blocks/BackgroundEllipses";
 
 // Finazch Dashboard inspired UI components
 
@@ -82,7 +83,22 @@ export default function ProfileDetailPage() {
   return (
     <div className="h-screen w-full relative flex flex-col overflow-hidden">
       {/* Background gradient */}
-      <div className="absolute inset-0 bg-gradient-to-t from-[#b4d9d6] to-[#58aadb]" />
+      <div className="absolute inset-0 bg-gradient-to-t from-[#7bc8e8] via-[#58aadb] to-[#2d8cd9]" />
+      
+      {/* テクスチャ効果 */}
+      <div className="absolute inset-0 opacity-20 pointer-events-none" style={{
+        backgroundImage: `url("data:image/svg+xml,${encodeURIComponent(`
+          <svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+            <filter id="noiseFilter">
+              <feTurbulence type="fractalNoise" baseFrequency="1.5" numOctaves="4" stitchTiles="stitch"/>
+            </filter>
+            <rect width="100%" height="100%" filter="url(#noiseFilter)"/>
+          </svg>
+        `)}")`
+      }}></div>
+      
+      {/* 背景装飾 */}
+      <BackgroundEllipses scale={0.8} />
       
       {/* Header */}
       <div className="relative z-10 px-6 lg:px-8 py-4">
@@ -95,9 +111,12 @@ export default function ProfileDetailPage() {
             <span className="font-medium text-xs">検索に戻る</span>
           </button>
           
-          <h1 className="font-semibold text-white text-sm tracking-wide">
+          <button
+            onClick={() => router.push('/dashboard')}
+            className="font-semibold text-white text-sm tracking-wide hover:text-white/80 transition-colors cursor-pointer"
+          >
             METI Picks
-          </h1>
+          </button>
         </div>
 
         {/* Profile Header Card */}


### PR DESCRIPTION
## 概要
人物プロフィールページのUI改善を行い、他のページとの統一性を向上させました。

## 変更内容

### �� 背景の統一
- 背景グラデーションを他のページと統一（`from-[#7bc8e8] via-[#58aadb] to-[#2d8cd9]`）
- テクスチャ効果（SVGノイズフィルター）を追加
- 背景装飾（`BackgroundEllipses`コンポーネント）を追加

### �� ナビゲーション改善
- METI Picksタイトルをクリックでダッシュボード（`/dashboard`）に遷移する機能を追加
- ホバー効果とスムーズな色の変化を実装

## 技術的変更
- `src/app/profile/[id]/page.tsx` の修正
- `BackgroundEllipses`コンポーネントのインポート追加
- 背景スタイリングの統一化

## 確認事項
- [x] ローカルでのビルド確認済み
- [x] コンフリクト確認済み
- [x] 他のページとの背景統一確認済み

## スクリーンショット
（必要に応じて追加）