### PR TITLE
fix: SVGファイルが表示されない問題を修正

### DIFF
--- a/.github/workflows/main_aps-agent0-02.yml
+++ b/.github/workflows/main_aps-agent0-02.yml
@@ -37,6 +37,7 @@ jobs:
           mkdir deploy
           cp -r ./.next/standalone/. ./deploy
           cp -r ./.next/static/. ./deploy/.next/static
+          cp -r ./public/. ./deploy/public
   
       - name: Zip artifact for deployment
         run: zip release.zip ./deploy -r 


### PR DESCRIPTION
## 概要
SVGファイルが表示されない問題を修正

## 問題
- GitHub Actionsのワークフローで`public`ディレクトリがコピーされていない
- Azure Web AppにデプロイされたファイルにSVGファイルが存在しない
- 結果として、SVGアイコンや背景画像が表示されない

## 修正内容
- `.github/workflows/main_aps-agent0-02.yml`に`cp -r ./public/. ./deploy/public`を追加
- これにより、`public`ディレクトリ内のSVGファイルがAzure Web Appにデプロイされる

## 影響するファイル
- `file.svg`
- `network-search-bg.svg` 
- `policy-submit-bg.svg`
- `comments-view-bg.svg`
- その他のSVGファイル

## テスト
- ローカルでビルド確認済み
- デプロイ構造の確認済み