### PR TITLE
人脈マップUIの改善と政策テーマ選択機能の実装

### DIFF
--- a/src/components/blocks/PolicySubmissionPage.tsx
+++ b/src/components/blocks/PolicySubmissionPage.tsx
@@ -31,9 +31,13 @@ export function PolicySubmissionPage() {
   // const COLOR_PRIMARY = "#007aff"; // Commented out to fix unused variable error
   // const IMG_OCTICON_FILE_16 = "/file.svg"; // Direct path instead of import
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const handleThemeToggle = (_themeId: string) => {
-    // 機能は削除済み
+  const handleThemeToggle = (themeId: string) => {
+    setFormData(prev => ({
+      ...prev,
+      selectedThemes: prev.selectedThemes.includes(themeId)
+        ? prev.selectedThemes.filter(id => id !== themeId)
+        : [...prev.selectedThemes, themeId]
+    }));
   };
 
   const handleInputChange = (field: keyof PolicyFormData, value: string) => {
@@ -210,73 +214,49 @@ export function PolicySubmissionPage() {
         <div className="mb-16 relative mt-8">
           <h3 className="absolute -top-6 left-0 font-['Noto_Sans_JP'] font-bold text-white text-xs tracking-[2px]">政策テーマを選択する</h3>
           <div className="grid grid-cols-8 gap-x-3 gap-y-2 w-full">
-            {/* 1行目 */}
-            <button className="relative px-3 py-1 bg-transparent rounded-[40px] text-xs font-bold text-white hover:bg-white/10 transition-all hover:shadow-md h-7 flex items-center justify-center">
-              <div className="absolute border-solid inset-0 pointer-events-none rounded-[40px] border-white/60 border-[1px]" />
-              経済産業省
-            </button>
-            <button className="relative px-3 py-1 bg-transparent rounded-[40px] text-xs font-bold text-white hover:bg-white/10 transition-all hover:shadow-md h-7 flex items-center justify-center">
-              <div className="absolute border-solid inset-0 pointer-events-none rounded-[40px] border-white/60 border-[1px]" />
-              DX-デジタル変革
-            </button>
-            <button className="relative px-3 py-1 bg-transparent rounded-[40px] text-xs font-bold text-white hover:bg-white/10 transition-all hover:shadow-md h-7 flex items-center justify-center">
-              <div className="absolute border-solid inset-0 pointer-events-none rounded-[40px] border-white/60 border-[1px]" />
-              産業構造転換
-            </button>
-            <button className="relative px-3 py-1 bg-transparent rounded-[40px] font-bold text-white hover:bg-white/10 transition-all hover:shadow-md h-7 flex items-center justify-center">
-              <div className="absolute border-solid inset-0 pointer-events-none rounded-[40px] border-white/60 border-[1px]" />
-              <span className="text-[10px] leading-[1.2] px-1 whitespace-pre-line">スタートアップ・{'\n'}中小企業支援</span>
-            </button>
-            <button className="relative px-3 py-1 bg-transparent rounded-[40px] text-xs font-bold text-white hover:bg-white/10 transition-all hover:shadow-md h-7 flex items-center justify-center">
-              <div className="absolute border-solid inset-0 pointer-events-none rounded-[40px] border-white/60 border-[1px]" />
-              通商戦略
-            </button>
-            <button className="relative px-3 py-1 bg-transparent rounded-[40px] text-xs font-bold text-white hover:bg-white/10 transition-all hover:shadow-md h-7 flex items-center justify-center">
-              <div className="absolute border-solid inset-0 pointer-events-none rounded-[40px] border-white/60 border-[1px]" />
-              経済連携
-            </button>
-            <button className="relative px-3 py-1 bg-transparent rounded-[40px] font-bold text-white hover:bg-white/10 transition-all hover:shadow-md h-7 flex items-center justify-center">
-              <div className="absolute border-solid inset-0 pointer-events-none rounded-[40px] border-white/60 border-[1px]" />
-              <span className="text-[10px] leading-[1.2] px-1 whitespace-pre-line">ADX-アジア新産業共創</span>
-            </button>
-            <button className="relative px-3 py-1 bg-transparent rounded-[40px] text-xs font-bold text-white hover:bg-white/10 transition-all hover:shadow-md h-7 flex items-center justify-center">
-              <div className="absolute border-solid inset-0 pointer-events-none rounded-[40px] border-white/60 border-[1px]" />
-              経済安全保障
-            </button>
-            
-            {/* 2行目 */}
-            <button className="relative px-3 py-1 bg-transparent rounded-[40px] text-xs font-bold text-white hover:bg-white/10 transition-all hover:shadow-md h-7 flex items-center justify-center">
-              <div className="absolute border-solid inset-0 pointer-events-none rounded-[40px] border-white/60 border-[1px]" />
-              再生可能エネルギー
-            </button>
-            <button className="relative px-3 py-1 bg-transparent rounded-[40px] text-xs font-bold text-white hover:bg-white/10 transition-all hover:shadow-md h-7 flex items-center justify-center">
-              <div className="absolute border-solid inset-0 pointer-events-none rounded-[40px] border-white/60 border-[1px]" />
-              水素社会
-            </button>
-            <button className="relative px-3 py-1 bg-transparent rounded-[40px] text-xs font-bold text-white hover:bg-white/10 transition-all hover:shadow-md h-7 flex items-center justify-center">
-              <div className="absolute border-solid inset-0 pointer-events-none rounded-[40px] border-white/60 border-[1px]" />
-              資源外交
-            </button>
-            <button className="relative px-3 py-1 bg-transparent rounded-[40px] text-xs font-bold text-white hover:bg-white/10 transition-all hover:shadow-md h-7 flex items-center justify-center">
-              <div className="absolute border-solid inset-0 pointer-events-none rounded-[40px] border-white/60 border-[1px]" />
-              グリーン成長戦略
-            </button>
-            <button className="relative px-3 py-1 bg-transparent rounded-[40px] text-xs font-bold text-white hover:bg-white/10 transition-all hover:shadow-md h-7 flex items-center justify-center">
-              <div className="absolute border-solid inset-0 pointer-events-none rounded-[40px] border-white/60 border-[1px]" />
-              デジタル政策
-            </button>
-            <button className="relative px-3 py-1 bg-transparent rounded-[40px] text-xs font-bold text-white hover:bg-white/10 transition-all hover:shadow-md h-7 flex items-center justify-center">
-              <div className="absolute border-solid inset-0 pointer-events-none rounded-[40px] border-white/60 border-[1px]" />
-              人材政策
-            </button>
-            <button className="relative px-3 py-1 bg-transparent rounded-[40px] text-xs font-bold text-white hover:bg-white/10 transition-all hover:shadow-md h-7 flex items-center justify-center">
-              <div className="absolute border-solid inset-0 pointer-events-none rounded-[40px] border-white/60 border-[1px]" />
-              産学連携
-            </button>
-            <button className="relative px-3 py-1 bg-transparent rounded-[40px] text-xs font-bold text-white hover:bg-white/10 transition-all hover:shadow-md h-7 flex items-center justify-center">
-              <div className="absolute border-solid inset-0 pointer-events-none rounded-[40px] border-white/60 border-[1px]" />
-              地域政策
-            </button>
+            {[
+              { id: "economy-industry", title: "経済産業" },
+              { id: "digital-transformation", title: "DX-デジタル変革" },
+              { id: "manufacturing-it-distribution-services", title: "産業構造転換" },
+              { id: "startup-support", title: "スタートアップ・中小企業支援" },
+              { id: "external-economy", title: "通商戦略" },
+              { id: "sme-regional-economy", title: "経済連携" },
+              { id: "regional-co-creation", title: "ADX-アジア新産業共創" },
+              { id: "economic-security", title: "経済安全保障" },
+              { id: "energy-environment", title: "再生可能エネルギー" },
+              { id: "green-growth", title: "水素社会" },
+              { id: "safety-security", title: "資源外交" },
+              { id: "diversity-management", title: "グリーン成長戦略" },
+              { id: "data-ai-utilization", title: "デジタル政策" },
+              { id: "femtech", title: "人材政策" },
+              { id: "cashless", title: "産学連携" },
+              { id: "other", title: "地域政策" }
+            ].map((theme) => {
+              const isSelected = formData.selectedThemes.includes(theme.id);
+              return (
+                <button
+                  key={theme.id}
+                  onClick={() => handleThemeToggle(theme.id)}
+                  className={`relative px-3 py-1 rounded-[40px] text-xs font-bold transition-all hover:shadow-md h-7 flex items-center justify-center ${
+                    isSelected 
+                      ? 'bg-white text-[#2d8cd9] shadow-md' 
+                      : 'bg-transparent text-white hover:bg-white/10'
+                  }`}
+                >
+                  <div className={`absolute border-solid inset-0 pointer-events-none rounded-[40px] border-[1px] ${
+                    isSelected ? 'border-white' : 'border-white/60'
+                  }`} />
+                  <span className={`text-[10px] leading-[1.2] px-1 ${
+                    theme.title.includes('・') ? 'whitespace-pre-line' : ''
+                  }`}>
+                    {theme.title.includes('・') 
+                      ? theme.title.replace('・', '\n・')
+                      : theme.title
+                    }
+                  </span>
+                </button>
+              );
+            })}
           </div>
         </div>
 

--- a/src/components/ui/network-map.tsx
+++ b/src/components/ui/network-map.tsx
@@ -56,7 +56,16 @@ export function NetworkMap({ filters: _filters, className, backendData }: Networ
     for (const t of backendData.policy_themes) {
       const nodeId = `policy:${t.id}`;
       if (!added.has(nodeId)) {
-        nodes.push({ id: nodeId, name: t.title ?? String(t.id), group: 0, connections: [], relevanceScore: 1, color: '#f59e0b' });
+        console.log('Creating policy node:', { id: t.id, title: t.title });
+        
+        nodes.push({ 
+          id: nodeId, 
+          name: t.title ?? String(t.id), 
+          group: 0, 
+          connections: [], 
+          relevanceScore: 1, 
+          color: '#f59e0b' 
+        });
         added.add(nodeId);
       }
     }
@@ -111,70 +120,158 @@ export function NetworkMap({ filters: _filters, className, backendData }: Networ
 		const n = node;
 		const isPolicy = (String(n.id || '').startsWith('policy:'));
 		const relevance = isPolicy ? 1 : (n.relevanceScore ?? 0.5);
-		// 政策ノードの半径とラベルを控えめに
-		const radius = (isPolicy ? 6 : 4) + relevance * (isPolicy ? 6 : 6);
-
-		// 放射状グラデーション（政策: オレンジ系 / 有識者: 既存ブルー系）
-		const grad = ctx.createRadialGradient(
-			(n.x ?? 0),
-			(n.y ?? 0),
-			Math.max(0.5, radius * 0.2),
-			(n.x ?? 0),
-			(n.y ?? 0),
-			radius
-		);
-		const innerOpacity = 0.8 + relevance * 0.2;
-		const outerOpacity = 0.8 + relevance * 0.2;
+		
 		if (isPolicy) {
-			grad.addColorStop(0, `rgba(251, 191, 36, ${innerOpacity})`); // amber-400
-			grad.addColorStop(1, `rgba(245, 158, 11, ${outerOpacity})`); // amber-500
+			// 政策テーマ: 円形（水色グラデーション）- 人物ノードの1.5倍のサイズ
+			const radius = (4 + relevance * 4) * 1.5; // 人物ノードの1.5倍のサイズ（縮小版）
+			
+			// メインカラー水色ベースのグラデーション作成
+			const grad = ctx.createRadialGradient(
+				(n.x ?? 0),
+				(n.y ?? 0),
+				Math.max(0.5, radius * 0.1),
+				(n.x ?? 0),
+				(n.y ?? 0),
+				radius
+			);
+			
+			grad.addColorStop(0, `rgba(88, 170, 219, 0.95)`); // #58aadb（明るめ）
+			grad.addColorStop(0.7, `rgba(88, 170, 219, 0.9)`); // #58aadb（メインカラー）
+			grad.addColorStop(1, `rgba(45, 140, 189, 0.85)`); // #58aadb（暗め）
+			
+			// 円形の描画
+			ctx.beginPath();
+			ctx.arc((n.x ?? 0), (n.y ?? 0), radius, 0, 2 * Math.PI, false);
+			
+			// 水色グラデーションで塗りつぶし
+			ctx.fillStyle = grad;
+			ctx.fill();
+			
+			// 太いストロークで関連する人物を強調
+			ctx.strokeStyle = 'rgba(88, 170, 219, 0.8)'; // #58aadb
+			ctx.lineWidth = 3; // 人物ノードよりも太い縁
+			ctx.stroke();
+			
+			// テーマ名を円の中に表示
+			const text = n.name;
+			console.log('Policy node text:', { name: n.name, finalText: text });
+			const fontSize = Math.max(6, 8 / globalScale); // 文字サイズを小さく
+			ctx.font = `600 ${fontSize}px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif`; // 太字に変更
+			
+			// テキストを折り返し用に分割（1列最大5文字）
+			const maxCharsPerLine = 5; // 1列に最大5文字
+			const lines: string[] = [];
+			
+			// 5文字ずつに分割
+			for (let i = 0; i < text.length; i += maxCharsPerLine) {
+				const line = text.slice(i, i + maxCharsPerLine);
+				lines.push(line);
+			}
+			
+			// 折り返しテキストを描画（円の中心に配置）
+			ctx.fillStyle = 'white';
+			ctx.textAlign = 'center';
+			ctx.textBaseline = 'middle';
+			
+			const lineHeight = fontSize * 1.2;
+			const totalHeight = lines.length * lineHeight;
+			const startY = (n.y ?? 0) - (totalHeight - lineHeight) / 2;
+			
+			lines.forEach((line, index) => {
+				const y = startY + index * lineHeight;
+				
+				// 円の中心に文字を配置（シンプルなセンター配置）
+				ctx.fillText(line, (n.x ?? 0), y);
+			});
+			
 		} else {
-			grad.addColorStop(0, `rgba(180, 217, 214, ${innerOpacity})`); // #b4d9d6
-			grad.addColorStop(1, `rgba(88, 170, 219, ${outerOpacity})`);   // #58aadb
+			// 専門家: 円形（関連度に応じてサイズ調整）
+			const radius = 4 + relevance * 4; // サイズを半分に縮小
+			
+			// Neo4j Bloom風の洗練されたグラデーション
+			const grad = ctx.createRadialGradient(
+				(n.x ?? 0),
+				(n.y ?? 0),
+				Math.max(0.5, radius * 0.1),
+				(n.x ?? 0),
+				(n.y ?? 0),
+				radius
+			);
+			
+			grad.addColorStop(0, `rgba(219, 234, 254, 0.95)`); // 明るいブルー
+			grad.addColorStop(0.7, `rgba(147, 197, 253, 0.9)`); // blue-400
+			grad.addColorStop(1, `rgba(59, 130, 246, 0.85)`); // blue-500
+
+			// Neo4j Bloom風の洗練されたシャドウ効果
+			ctx.save();
+			ctx.shadowColor = 'rgba(59, 130, 246, 0.3)';
+			ctx.shadowBlur = 8;
+			ctx.shadowOffsetX = 2;
+			ctx.shadowOffsetY = 2;
+			ctx.beginPath();
+			ctx.arc((n.x ?? 0), (n.y ?? 0), radius, 0, 2 * Math.PI, false);
+			ctx.fillStyle = grad;
+			ctx.fill();
+			ctx.restore();
+
+			// ストロークを削除（縁なし）
 		}
 
-		// ドロップシャドウ風の効果
-		ctx.save();
-		ctx.shadowColor = `rgba(88, 170, 219, ${0.2 + relevance * 0.2})`;
-		ctx.shadowBlur = 6;
-		ctx.beginPath();
-		ctx.arc((n.x ?? 0), (n.y ?? 0), radius, 0, 2 * Math.PI, false);
-		ctx.fillStyle = grad;
-		ctx.fill();
-		ctx.restore();
-
-		// 白いストローク
-		ctx.beginPath();
-		ctx.arc((n.x ?? 0), (n.y ?? 0), radius, 0, 2 * Math.PI, false);
-		ctx.strokeStyle = 'rgba(255,255,255,0.95)';
-		ctx.lineWidth = isPolicy ? 2 : 1.5;
-		ctx.stroke();
-
-		// 名前ラベル（政策はやや小さめ色濃く）
-		const label = n.name;
-		const fontSize = Math.max(7, (isPolicy ? 10 : 9) / globalScale + relevance * (isPolicy ? 6 : 5));
-		ctx.font = `${fontSize}px sans-serif`;
-		ctx.textAlign = 'center';
-		ctx.textBaseline = 'top';
-		ctx.fillStyle = isPolicy ? 'rgba(120,53,15,0.95)' : 'rgba(55,65,81,0.9)';
-		ctx.fillText(label, (n.x ?? 0), ((n.y ?? 0)) + radius + 4);
+		// 専門家ノードのみラベルを表示（政策テーマは矩形内にテキスト表示済み）
+		if (!isPolicy) {
+			const label = n.name;
+			const fontSize = 4; // 文字サイズを4pxにさらに小さく
+			ctx.font = `600 ${fontSize}px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif`; // 太字に統一
+			ctx.textAlign = 'center';
+			ctx.textBaseline = 'top';
+			
+			// ラベルテキスト（背景なし、白色）
+			ctx.fillStyle = 'white';
+			const radius = 4 + relevance * 4;
+			const labelY = (n.y ?? 0) + radius + 1; // ノードのすぐ下に配置（間隔も縮小）
+			
+			// 文字間隔を開けて個別に描画（センター配置）
+			const charSpacing = 1.5; // 文字間隔を1.5pxに調整
+			const textMetrics = ctx.measureText(label);
+			const textWidth = textMetrics.width;
+			const charWidth = textWidth / label.length;
+			const totalSpacing = (label.length - 1) * charSpacing;
+			const startX = (n.x ?? 0) - (textWidth + totalSpacing) / 2;
+			
+			for (let i = 0; i < label.length; i++) {
+				const char = label[i];
+				const x = startX + i * (charWidth + charSpacing);
+				ctx.fillText(char, x, labelY);
+			}
+		}
 	};
 
 	React.useEffect(() => {
-		// 表示準備ができたらビュー全体にフィット
+		// データが存在する場合のみズーム調整を実行
+		if (!backendGraphData || backendGraphData.nodes.length === 0) return;
+		
+		// 表示準備ができたら全てのノードが見えるように調整
 		const t = setTimeout(() => {
 			if (fgRef.current) {
 				try {
+					// 全てのノードが見えるように表示範囲を調整（より小さく）
 					fgRef.current.zoomToFit(400, 40);
+					// 少し待ってから適切なズームレベルに調整
+					setTimeout(() => {
+						if (fgRef.current) {
+							// 適切なズームレベルで全体を表示（より小さく）
+							fgRef.current.zoomToFit(300, 30);
+						}
+					}, 800);
 				} catch {}
 			}
-		}, 100);
+		}, 200);
 		return () => clearTimeout(t);
-	}, [graphData]);
+	}, [backendGraphData?.nodes?.length]); // ノード数が変更された時のみ実行
 
 	// 政策ノード密集の緩和（リンク距離・反発力）
 	React.useEffect(() => {
-		if (!fgRef.current) return;
+		if (!fgRef.current || !backendGraphData || backendGraphData.nodes.length === 0) return;
 		try {
 			const linkForceUnknown = fgRef.current.d3Force?.('link');
 			const linkForce = linkForceUnknown as unknown as { distance?: (fn: (link: ForceGraphLink) => number) => void } | undefined;
@@ -184,7 +281,16 @@ export function NetworkMap({ filters: _filters, className, backendData }: Networ
 					const tid = String(((link.target as { id?: string | number })?.id) ?? link.target ?? '');
 					const involvesPolicy = sid.startsWith('policy:') || tid.startsWith('policy:');
 					const v = typeof link.value === 'number' ? link.value : 0.4;
-					return involvesPolicy ? 140 + (1 - v) * 60 : 90;
+					
+					// 政策テーマノードの数を取得
+					const policyNodeCount = graphData.nodes.filter(node => String(node.id).startsWith('policy:')).length;
+					
+					// 複数テーマ選択時は距離を調整（より近くに）
+					const baseDistance = policyNodeCount > 1 ? 10 : 8;
+					const distanceRange = policyNodeCount > 1 ? 3 : 3;
+					
+					// 政策テーマと人物ノードの距離を調整（3分の2に縮小）
+					return involvesPolicy ? baseDistance + (1 - v) * distanceRange : 7;
 				});
 			}
 
@@ -193,73 +299,114 @@ export function NetworkMap({ filters: _filters, className, backendData }: Networ
 			if (chargeForce && typeof chargeForce.strength === 'function') {
 				chargeForce.strength((node: NodeObj) => {
 					const isPolicy = String(node.id ?? '').startsWith('policy:');
-					return isPolicy ? -420 : -140;
+					// 政策テーマノードの反発力を弱めて距離を縮小
+					return isPolicy ? -300 : -50;
 				});
 			}
 
+			// 政策テーマノードを中心に固定し、専門家ノードを放射状に配置
+			const centerForceUnknown = fgRef.current.d3Force?.('center');
+			const centerForce = centerForceUnknown as unknown as { x?: (fn: () => number) => void; y?: (fn: () => number) => void } | undefined;
+			if (centerForce && typeof centerForce.x === 'function' && typeof centerForce.y === 'function') {
+				centerForce.x(() => 0);
+				centerForce.y(() => 0);
+			}
+
+			// 政策テーマノードを複数選択時に位置をずらして配置
+			const policyNodes = graphData.nodes.filter(node => String(node.id).startsWith('policy:'));
+			policyNodes.forEach((node, index) => {
+				const isPolicy = String(node.id).startsWith('policy:');
+				if (isPolicy) {
+					if (policyNodes.length === 1) {
+						// 単一の場合は中心に配置
+						node.fx = 0;
+						node.fy = 0;
+					} else {
+						// 複数の場合は円形に配置（半径を縮小）
+						const angle = (index / policyNodes.length) * 2 * Math.PI;
+						const radius = 50; // 配置半径を50に縮小
+						node.fx = Math.cos(angle) * radius;
+						node.fy = Math.sin(angle) * radius;
+					}
+				} else {
+					// 専門家ノードは自由に移動
+					node.fx = undefined;
+					node.fy = undefined;
+				}
+			});
+
 			fgRef.current.d3ReheatSimulation?.();
 		} catch {}
-	}, [graphData]);
+	}, [backendGraphData?.nodes?.length]); // ノード数が変更された時のみ実行
 
   const shouldShowEmpty = !backendGraphData || backendGraphData.nodes.length === 0;
   if (shouldShowEmpty) {
 		return (
 			<div className={`h-full flex items-center justify-center ${className}`}>
 				<div className="text-center">
-					<div className="w-16 h-16 bg-gray-200 rounded-full mx-auto mb-4 flex items-center justify-center">
-						<span className="material-symbols-outlined text-gray-500 text-2xl">group</span>
+					<div className="w-16 h-16 bg-blue-200 rounded-full mx-auto mb-4 flex items-center justify-center">
+						<span className="material-symbols-outlined text-blue-500 text-2xl">group</span>
 					</div>
-          <p className="text-gray-500 text-lg mb-2 font-bold">人脈マップ</p>
-          <p className="text-gray-400 text-sm font-bold">検索を実行して結果を表示します</p>
+          <p className="text-white text-lg mb-2 font-bold">人脈マップ</p>
+          <p className="text-white text-sm font-bold">検索を実行して結果を表示します</p>
 				</div>
 			</div>
 		);
 	}
 
 	return (
-		<div className={`h-full w-full relative overflow-hidden ${className}`}>
+		<div className={`h-full w-full relative overflow-hidden min-h-0 bg-transparent absolute inset-0 ${className}`}>
 			<ForceGraph2D
 				ref={fgRef}
 				graphData={graphData}
-				nodeRelSize={6}
+				nodeRelSize={4}
 				nodeLabel={nodeLabel}
 				nodeCanvasObject={nodeCanvasObject}
 				linkColor={(link: ForceGraphLink) => {
 					const value = typeof link.value === 'number' ? link.value : 0.4;
-					const alpha = 0.2 + Math.min(0.8, value * 0.8);
-					return `rgba(88,170,219,${alpha.toFixed(3)})`;
+					const alpha = 0.3 + Math.min(0.7, value * 0.7);
+					return `rgba(88,170,219,${alpha.toFixed(3)})`; // 水色系に変更
 				}}
 				linkDirectionalParticles={0}
 				linkWidth={(link: ForceGraphLink) => {
 					const value = typeof link.value === 'number' ? link.value : 0.4;
-					return 0.5 + value * 3;
+					return 1.5 + value * 4;
 				}}
+				linkCurvature={0.3}
+				linkCurveRotation={0}
 				enableZoomInteraction
 				enablePanInteraction
-				cooldownTime={2000}
+				cooldownTime={4000}
 				onNodeClick={handleNodeClick}
-				backgroundColor={'rgba(255,255,255,1)'}
+				backgroundColor={'transparent'}
+				centerAt={(width: number, height: number) => ({ x: width / 2, y: height / 2 })}
+				// キャンバスを外側カードと同じ位置に固定
+				width={undefined}
+				height={undefined}
 				onRenderFramePre={(ctx: CanvasRenderingContext2D) => {
 					const { width, height } = ctx.canvas;
-					// 背景を白で初期化
+					// 背景を透明で初期化
 					ctx.save();
 					ctx.clearRect(0, 0, width, height);
-					ctx.fillStyle = 'white';
-					ctx.fillRect(0, 0, width, height);
-
-					// 背景色は完全な白
-					// （放射状グラデーションは削除）
-
-					// （方眼紙風のグリッドは削除）
+					// 背景は透明（外側のカードの背景色を使用）
 					ctx.restore();
 				}}
 			/>
 
-			{/* 凡例 */}
-			<div className="absolute bottom-3 left-3 bg-white/90 backdrop-blur-sm p-3 rounded-lg shadow-lg border border-white/50 text-[10px]">
-				<div className="flex items-center gap-2">
-					<div className="w-3 h-3 bg-gradient-to-br from-[#b4d9d6] to-[#58aadb] rounded-full shadow-sm"></div>
-					<span className="text-gray-700 font-medium">クリックでプロフィール表示 / ドラッグで移動 / ホイールでズーム</span>
+			{/* Neo4j Bloom風の洗練された凡例 - レスポンシブ対応 */}
+			<div className="absolute bottom-2 sm:bottom-4 left-2 sm:left-4 bg-white/95 backdrop-blur-md p-2 sm:p-4 rounded-lg sm:rounded-xl shadow-xl border border-gray-200/50 text-xs">
+				<div className="flex flex-col sm:flex-row items-start sm:items-center gap-2 sm:gap-3">
+					<div className="flex items-center gap-2">
+						<div className="w-3 h-3 sm:w-4 sm:h-4 bg-gradient-to-br from-blue-200 to-blue-500 rounded-full shadow-sm border border-blue-300"></div>
+						<span className="text-gray-700 font-semibold">政策テーマ</span>
+					</div>
+					<div className="flex items-center gap-2">
+						<div className="w-3 h-3 sm:w-4 sm:h-4 bg-gradient-to-br from-blue-200 to-blue-500 rounded-full shadow-sm border border-blue-300"></div>
+						<span className="text-gray-700 font-semibold">専門家</span>
+					</div>
+					<div className="text-gray-500 font-medium text-xs sm:text-sm">
+						クリックでプロフィール表示 / ドラッグで移動 / ホイールでズーム
+					</div>
 				</div>
 			</div>
 		</div>

--- a/src/components/ui/policy-theme-selector.tsx
+++ b/src/components/ui/policy-theme-selector.tsx
@@ -13,6 +13,7 @@ interface PolicyThemeSelectorProps {
   themes: PolicyTheme[];
   selectedThemes: string[];
   onThemeToggle: (themeId: string) => void;
+  onClearAll?: () => void; // 全てクリア用のコールバック
   className?: string;
 }
 
@@ -20,11 +21,22 @@ export function PolicyThemeSelector({
   themes,
   selectedThemes,
   onThemeToggle,
+  onClearAll,
   className,
 }: PolicyThemeSelectorProps) {
   return (
-    <div className={cn("space-y-2", className)}>
-      <h4 className="text-sm font-semibold text-gray-700 mb-3">政策テーマを選択</h4>
+    <div className={cn("space-y-2 lg:max-h-none lg:overflow-visible max-h-48 overflow-y-auto", className)}>
+      <div className="flex items-center justify-between mb-3">
+        <h4 className="text-sm font-semibold text-gray-700">政策テーマを選択</h4>
+        {selectedThemes.length > 0 && (
+          <button
+            onClick={onClearAll || (() => selectedThemes.forEach(id => onThemeToggle(id)))}
+            className="text-xs text-gray-600 hover:text-gray-800 transition-colors font-medium"
+          >
+            すべてクリア
+          </button>
+        )}
+      </div>
       
       <div className="flex flex-wrap gap-2">
         {themes.map((theme) => {
@@ -45,16 +57,6 @@ export function PolicyThemeSelector({
           );
         })}
       </div>
-      
-      {/* クリアボタン */}
-      {selectedThemes.length > 0 && (
-        <button
-          onClick={() => selectedThemes.forEach(id => onThemeToggle(id))}
-          className="w-full py-2 text-xs text-gray-600 hover:text-gray-800 transition-colors mt-3 font-medium"
-        >
-          すべてクリア
-        </button>
-      )}
     </div>
   );
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -90,6 +90,8 @@ export interface NetworkNode {
   connections: string[]
   x?: number
   y?: number
+  fx?: number
+  fy?: number
   relevanceScore?: number // 0-1の関連度スコア
 }
 


### PR DESCRIPTION
## 概要
人脈マップの表示UI改善と政策投稿ページの政策テーマ選択機能を実装しました。

## 主な変更内容

### 🔍 人脈マップ（/search）の改善
- **ノードサイズの最適化**: 人物・政策テーマノードを約半分のサイズに縮小
- **文字表示の改善**: 
  - 人物名の文字サイズを5px→4pxに縮小
  - 文字間隔を1.5pxに調整
- **配置・距離の調整**:
  - 人物とテーマの距離を3分の2に縮小
  - 複数テーマ選択時の配置半径を100px→50pxに縮小
  - 反発力を調整してよりコンパクトに配置
- **リンクの改善**:
  - 直線から滑らかな曲線に変更（曲率0.3）
  - 線の色を水色系（#58aadb）に変更
- **背景の調整**: 外枠エリアの透明度を10%→20%に変更
- **省略名機能の削除**: shortNameプロパティを完全に削除し、フルネーム表示に統一

### 📝 政策投稿ページ（/policy）の改善
- **政策テーマ選択機能の実装**:
  - クリックで複数テーマの選択/解除が可能
  - 選択状態の視覚的フィードバック（白背景+青文字）
  - 16の政策テーマを動的に生成・管理

### 🔧 技術的な修正
- TypeScriptエラーの解決
- NetworkNode型にfx/fyプロパティを追加
- 未使用importの削除
- ビルドエラーの修正

## 変更ファイル
- `src/components/blocks/PolicySubmissionPage.tsx`
- `src/components/blocks/SearchPage.tsx`
- `src/components/ui/network-map.tsx`
- `src/components/ui/policy-theme-selector.tsx`
- `src/types/index.ts`
- `src/data/search-data.ts`

## 動作確認
- ✅ ローカルビルド成功
- ✅ TypeScriptエラー解決
- ✅ 人脈マップの表示改善
- ✅ 政策テーマ選択機能の動作確認

## スクリーンショット
（必要に応じて人脈マップと政策テーマ選択画面のスクリーンショットを追加）