### PR TITLE
feat: 返信コメント表示機能とUI/UX改善を実装

### DIFF
--- a/src/lib/comments-api.ts
+++ b/src/lib/comments-api.ts
@@ -1,4 +1,5 @@
 import { getToken } from "./storage";
+import { apiFetch } from "./apiClient";
 
 export interface Comment {
   id: string;
@@ -52,4 +53,74 @@ export async function fetchCommentsByPolicyId(
     console.error('コメント取得エラー:', error);
     return [];
   }
+}
+
+// 返信コメントを取得する関数（新しいバックエンドエンドポイントを使用）
+export async function fetchRepliesByCommentId(parentCommentId: string, limit: number = 20, offset: number = 0): Promise<{
+  replies: Comment[];
+  total_count: number;
+  has_more: boolean;
+}> {
+  try {
+    const response = await apiFetch<{
+      replies: Comment[];
+      total_count: number;
+      has_more: boolean;
+    }>(`/api/policy-proposal-comments/${parentCommentId}/replies?limit=${limit}&offset=${offset}`, { auth: true });
+    
+    return response;
+  } catch (error) {
+    console.error('返信コメント取得エラー:', error);
+    // エラーの詳細を確認
+    if (error instanceof Error) {
+      if (error.message.includes('Invalid comment ID format')) {
+        throw new Error('無効なコメントIDです');
+      } else if (error.message.includes('Parent comment not found')) {
+        throw new Error('コメントが見つかりません');
+      } else {
+        throw new Error('返信コメントの取得に失敗しました');
+      }
+    }
+    throw new Error('返信コメントの取得に失敗しました');
+  }
+}
+
+export async function fetchReplyCountByCommentId(parentCommentId: string): Promise<number> {
+  try {
+    const response = await apiFetch<{ reply_count: number }>(`/api/policy-proposal-comments/${parentCommentId}/replies/count`, { auth: true });
+    return response.reply_count || 0;
+  } catch (error) {
+    console.error('返信コメント数取得エラー:', error);
+    // エラーの詳細を確認
+    if (error instanceof Error) {
+      if (error.message.includes('Invalid comment ID format')) {
+        throw new Error('無効なコメントIDです');
+      } else if (error.message.includes('Parent comment not found')) {
+        throw new Error('コメントが見つかりません');
+      } else {
+        throw new Error('返信コメント数の取得に失敗しました');
+      }
+    }
+    return 0;
+  }
+}
+
+// コメントを親コメントと返信に分類する関数
+export function organizeComments(comments: Comment[]): {
+  parentComments: Comment[];
+  repliesByParent: Record<string, Comment[]>;
+} {
+  const parentComments = comments.filter(comment => !comment.parent_comment_id);
+  const repliesByParent: Record<string, Comment[]> = {};
+  
+  comments.forEach(comment => {
+    if (comment.parent_comment_id) {
+      if (!repliesByParent[comment.parent_comment_id]) {
+        repliesByParent[comment.parent_comment_id] = [];
+      }
+      repliesByParent[comment.parent_comment_id].push(comment);
+    }
+  });
+  
+  return { parentComments, repliesByParent };
 }


### PR DESCRIPTION
- 返信コメントの表示機能を実装
- 新しいバックエンドエンドポイントに対応
- 投稿履歴一覧に検索・フィルタリング・ページネーション機能を追加
- 表示件数制限（1ページ10件）を実装
- エラーハンドリングを改善
- UI/UXの大幅な改善