### PR TITLE
fix: ダッシュボードページのハードコーディングされたユーザー名を動的表示に変更

### DIFF
--- a/src/components/blocks/TopPageFitted.tsx
+++ b/src/components/blocks/TopPageFitted.tsx
@@ -1,14 +1,33 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import Image from "next/image"; // 追加
+import { useState, useEffect } from "react";
+import Image from "next/image";
+import { getUserName, getUserNameFromAPI } from "@/lib/auth";
 
 export default function TopPageFitted() {
   const router = useRouter();
+  const [userName, setUserName] = useState<string>("ログインユーザー");
 
   const handleGoToDashboard = () => {
     router.push('/dashboard');
   };
+
+  // ユーザー名を取得
+  useEffect(() => {
+    const fetchUserName = async () => {
+      try {
+        const name = await getUserNameFromAPI();
+        setUserName(name);
+      } catch {
+        // APIが失敗した場合はJWTトークンから取得
+        const fallbackName = getUserName();
+        setUserName(fallbackName);
+      }
+    };
+
+    fetchUserName();
+  }, []);
 
     return (
     <div className="relative h-screen w-screen overflow-hidden bg-gradient-to-t from-[#7bc8e8] via-[#58aadb] to-[#2d8cd9]">
@@ -55,7 +74,7 @@ export default function TopPageFitted() {
                 面談録のアップロード
               </button>
               <div className="text-white text-[12px] lg:text-[13.06px] font-semibold tracking-[1.5672px] bg-white/10 rounded-lg px-3 py-2 cursor-pointer hover:bg-white/20 transition-colors">
-                テックゼロ太郎さん
+                {userName}
               </div>
             </div>
           </div>


### PR DESCRIPTION
## 概要

ダッシュボードページ（/dashboard）でハードコーディングされていた「テックゼロ太郎」を動的なユーザー名表示に変更しました。

## 変更内容

- `TopPageFitted`コンポーネントにユーザー名取得ロジックを追加
- APIからユーザー名を取得し、失敗時はJWTトークンからフォールバック取得
- 実際のログインユーザーの名前が表示されるように修正

## 技術的な変更

- `useState`と`useEffect`を使用したユーザー名の状態管理
- `getUserName`と`getUserNameFromAPI`を使用したユーザー名取得
- ハードコーディングされた文字列を動的変数に置換

## テスト

- ✅ ビルドエラーなし
- ✅ 開発サーバーでの動作確認済み
- ✅ ユーザー名が正しく表示されることを確認

## 関連Issue

なし