### PR TITLE
feat: PolicyCommentsPageのパフォーマンス最適化とコンポーネント分離

### DIFF
--- a/src/components/blocks/PolicyCommentsPage.tsx
+++ b/src/components/blocks/PolicyCommentsPage.tsx
@@ -1,697 +1,31 @@
 "use client";
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import { PolicySubmission } from '@/types';
 import { fetchMyPolicySubmissions } from '@/lib/policy-api';
-import { fetchCommentsByPolicyId, fetchRepliesByCommentId, fetchReplyCountByCommentId, organizeComments, Comment, isFeedbackSubmitted, getFeedbackStates } from '@/lib/comments-api';
-import { saveCommentEvaluation, generateAIResponse, postAIResponse } from '@/lib/evaluation-api';
-import { getUserFromToken } from '@/lib/auth';
+import { organizeComments, isFeedbackSubmitted } from '@/lib/comments-api';
 import { Card } from '@/components/ui/card';
-import { CommentCount } from '@/components/ui/comment-count';
+
 import { CommentSkeletonList, PolicySubmissionSkeletonList } from '@/components/ui/skeleton';
 import { SuccessMessage } from '@/components/ui/success-message';
 import BackgroundEllipses from '@/components/blocks/BackgroundEllipses';
 import { Header } from '@/components/ui/header';
+import { usePolicyComments } from '@/hooks/usePolicyComments';
+import { useFeedbackSubmission } from '@/hooks/useFeedbackSubmission';
+import { CommentItem } from '@/components/blocks/policy-comments/CommentItem';
+import { FilterTabs } from '@/components/blocks/policy-comments/FilterTabs';
+import { EmptyState } from '@/components/blocks/policy-comments/EmptyState';
 
-// ステータスに応じた色とラベルを取得（現在は使用していないが将来の拡張用）
-const _getStatusInfo = (status: PolicySubmission['status']) => {
-  switch (status) {
-    case 'draft':
-      return { label: '下書き', color: 'bg-gray-500' };
-    case 'submitted':
-      return { label: '投稿済み', color: 'bg-blue-500' };
-    case 'under_review':
-      return { label: '審査中', color: 'bg-yellow-500' };
-    case 'approved':
-      return { label: '承認済み', color: 'bg-green-500' };
-    case 'rejected':
-      return { label: '却下', color: 'bg-red-500' };
-    default:
-      return { label: '不明', color: 'bg-gray-500' };
-  }
-};
-
-// フィルタタブコンポーネント
-const tabs = [
-  { id: "all", label: "すべて" },
-  { id: "unfb", label: "未FBのみ" },
-  { id: "fb", label: "FB済みのみ" },
-];
-
-const SimpleTabs = ({ activeTab, onChange, counts }: {
-  activeTab: string;
-  onChange: (id: string) => void;
-  counts: { all: number; unfb: number; fb: number; };
-}) => {
-  return (
-    <div className="flex border-b border-gray-200 mb-6">
-      {tabs.map((tab) => {
-        const count = counts[tab.id as keyof typeof counts];
-        return (
-          <button
-            key={tab.id}
-            onClick={() => onChange(tab.id)}
-            className={`px-4 py-2 text-sm font-medium transition-colors ${
-              activeTab === tab.id 
-                ? "border-b-2 border-[#4AA0E9] text-[#4AA0E9]" 
-                : "text-gray-500 hover:text-gray-700"
-            }`}
-          >
-            {tab.label}
-            {count > 0 && (
-              <span className="ml-2 bg-gray-100 text-gray-600 px-2 py-0.5 rounded-full text-xs">
-                {count}
-              </span>
-            )}
-          </button>
-        );
-      })}
-    </div>
-  );
-};
-
-// 評価ボタンコンポーネント
-const RatingButtons = ({ 
-  value, 
-  onChange, 
-  label,
-  description,
-  leftLabel,
-  rightLabel
-}: { 
-  value: number; 
-  onChange: (value: number) => void; 
-  label: string;
-  description?: string;
-  leftLabel?: string;
-  rightLabel?: string;
-}) => {
-  return (
-    <div className="space-y-2">
-              <div className="flex items-center gap-2">
-          <span className="text-xs font-medium text-gray-700 min-w-[80px]">{label}:</span>
-          <div className="flex gap-1">
-            {[1, 2, 3, 4, 5].map((rating) => (
-              <div key={rating} className="flex flex-col items-center">
-                <button
-                  onClick={() => onChange(rating)}
-                  className={`w-6 h-6 rounded border transition-all hover:scale-105 ${
-                    value >= rating
-                      ? 'bg-[#4AA0E9] border-[#4AA0E9] text-white shadow-sm'
-                      : 'bg-white border-gray-300 text-gray-400 hover:border-[#4AA0E9] hover:text-[#4AA0E9]'
-                  } flex items-center justify-center text-xs font-bold`}
-                >
-                  {rating}
-                </button>
-                                 {rating === 1 && leftLabel && (
-                   <span className="text-[8px] text-gray-500 mt-1 font-bold">{leftLabel}</span>
-                 )}
-                 {rating === 5 && rightLabel && (
-                   <span className="text-[8px] text-gray-500 mt-1 font-bold">{rightLabel}</span>
-                 )}
-              </div>
-            ))}
-          </div>
-
-        </div>
-      
-      {description && (
-        <p className="text-xs text-gray-600 leading-tight">{description}</p>
-      )}
-      
-
-    </div>
-  );
-};
-
-// コメント評価・返信フォームコンポーネント（詳細ビュー）
-const CommentFeedbackForm = ({ 
-  commentId, 
-  onSubmit,
-  onClose,
-  isSubmitting = false
-}: { 
-  commentId: string; 
-  onSubmit: (feedback: {
-    commentId: string;
-    overallRating: number;
-    empathyRating: number;
-    aiResponse: string;
-  }) => void;
-  onClose: () => void;
-  isSubmitting?: boolean;
-}) => {
-  const [overallRating, setOverallRating] = useState(0);
-  const [empathyRating, setEmpathyRating] = useState(0);
-  const [aiResponse, setAiResponse] = useState('');
-  const [isGenerating, setIsGenerating] = useState(false);
-  const [evaluationSaved, setEvaluationSaved] = useState(false);
-  const [_feedbackSaved, setFeedbackSaved] = useState(false);
-
-  const handleGenerateAIResponse = async () => {
-    setIsGenerating(true);
-    try {
-      const response = await generateAIResponse(commentId, {
-        persona: "丁寧で建設的な政策担当者",
-        instruction: "具体的な提案を含めて返信してください"
-      });
-      setAiResponse(response.suggested_reply);
-    } catch (error) {
-      console.error('AI返信生成エラー:', error);
-      setAiResponse('AI返信の生成に失敗しました。もう一度お試しください。');
-    } finally {
-      setIsGenerating(false);
-    }
-  };
-
-  const handleRegenerate = async () => {
-    setIsGenerating(true);
-    try {
-      const response = await generateAIResponse(commentId, {
-        persona: "建設的で批判的な視点を持つ政策担当者",
-        instruction: "別の視点から、より詳細な分析を含めて返信してください"
-      });
-      setAiResponse(response.suggested_reply);
-    } catch (error) {
-      console.error('AI返信再生成エラー:', error);
-      setAiResponse('AI返信の再生成に失敗しました。もう一度お試しください。');
-    } finally {
-      setIsGenerating(false);
-    }
-  };
-
-  const handleSaveEvaluation = async () => {
-    if (overallRating > 0 && empathyRating > 0) {
-      try {
-        await saveCommentEvaluation(commentId, {
-          overallRating,
-          empathyRating,
-        });
-        setEvaluationSaved(true);
-      } catch (error) {
-        console.error('評価保存エラー:', error);
-        alert('評価の保存に失敗しました');
-      }
-    }
-  };
-
-  const _handleSaveFeedback = () => {
-    if (aiResponse.trim()) {
-      // TODO: AI返信をコメントとして投稿
-      console.log('フィードバック保存:', { aiResponse });
-      setFeedbackSaved(true);
-    }
-  };
-
-  const handleSubmit = () => {
-    if (overallRating > 0 && empathyRating > 0 && aiResponse.trim()) {
-      onSubmit({
-        commentId,
-        overallRating,
-        empathyRating,
-        aiResponse
-      });
-    }
-  };
-
-  return (
-    <div className="bg-gray-50 rounded-lg border border-gray-200 p-4">
-      {/* ヘッダー */}
-      <div className="flex items-center justify-between mb-4">
-        <h3 className="text-base font-bold text-gray-900">意見の評価・返信</h3>
-        <button
-          onClick={onClose}
-          className="text-gray-400 hover:text-gray-600 transition-colors"
-        >
-          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-          </svg>
-        </button>
-      </div>
-
-      {/* 評価セクション */}
-      <div className="mb-4">
-        <h4 className="text-sm font-bold text-gray-900 mb-3">内部評価（非公開）</h4>
-        <div className="grid grid-cols-3 gap-4 items-start">
-          <RatingButtons 
-            value={overallRating} 
-            onChange={setOverallRating} 
-            label="意見の総合評価"
-            leftLabel="低い"
-            rightLabel="高い"
-          />
-          <RatingButtons 
-            value={empathyRating} 
-            onChange={setEmpathyRating} 
-            label="政策への共感度"
-            leftLabel="否定的"
-            rightLabel="肯定的"
-          />
-          <div className="flex justify-end items-end h-full">
-            <button
-              onClick={handleSaveEvaluation}
-              disabled={overallRating === 0 || empathyRating === 0}
-              className="px-3 py-1.5 bg-[#4AA0E9] text-white text-xs rounded hover:bg-[#3a8fd9] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              {evaluationSaved ? '• 評価保存済み' : '評価のみ保存'}
-            </button>
-          </div>
-        </div>
-      </div>
-
-      {/* AI返信セクション */}
-      <div className="mb-4">
-        <div className="flex items-center justify-between mb-3">
-          <h4 className="text-sm font-bold text-gray-900">フィードバック返信（公開）</h4>
-          <div className="flex gap-2">
-            <button
-              onClick={handleGenerateAIResponse}
-              disabled={isGenerating}
-              className="px-3 py-1.5 border border-[#4AA0E9] text-[#4AA0E9] text-xs rounded hover:bg-[#4AA0E9]/10 transition-colors disabled:opacity-50"
-            >
-              {isGenerating ? '生成中...' : 'AIフィードバックを生成'}
-            </button>
-            {aiResponse && (
-              <button
-                onClick={handleRegenerate}
-                disabled={isGenerating}
-                className="px-3 py-1 bg-gray-500 text-white text-xs rounded-lg hover:bg-gray-600 transition-colors disabled:opacity-50"
-              >
-                {isGenerating ? '生成中...' : '再生成'}
-              </button>
-            )}
-          </div>
-        </div>
-        
-        <textarea
-          value={aiResponse}
-          onChange={(e) => setAiResponse(e.target.value)}
-          placeholder="AIによって生成されたフィードバックが表示されます。編集してから投稿してください。"
-          className="w-full h-24 p-3 border border-[#4AA0E9]/30 rounded-lg resize-none text-sm focus:outline-none focus:ring-2 focus:ring-[#4AA0E9]/20"
-        />
-      </div>
-
-      {/* アクションボタン */}
-      <div className="flex justify-end gap-2">
-        <button
-          onClick={onClose}
-          className="px-2 py-1 text-gray-600 hover:text-gray-800 transition-colors text-xs"
-        >
-          キャンセル
-        </button>
-
-        <button
-          onClick={handleSubmit}
-          disabled={overallRating === 0 || empathyRating === 0 || !aiResponse.trim() || isSubmitting}
-          className="px-2 py-1 bg-[#4AA0E9] text-white text-xs rounded hover:bg-[#3a8fd9] transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-1"
-        >
-          {isSubmitting ? (
-            <>
-              <svg className="w-3 h-3 animate-spin" fill="none" viewBox="0 0 24 24">
-                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-              </svg>
-              投稿中...
-            </>
-          ) : (
-            '投稿'
-          )}
-        </button>
-      </div>
-    </div>
-  );
-};
-
-// 検索・フィルタリング・ページネーション用のUIコンポーネント
-const PolicyListControls = ({
-  searchTerm,
-  onSearchChange,
-  sortBy,
-  onSortChange,
-  currentPage,
-  totalPages,
-  onPageChange,
-  totalItems,
-  itemsPerPage
-}: {
-  searchTerm: string;
-  onSearchChange: (value: string) => void;
-  sortBy: "date" | "title";
-  onSortChange: (value: "date" | "title") => void;
-  currentPage: number;
-  totalPages: number;
-  onPageChange: (page: number) => void;
-  totalItems: number;
-  itemsPerPage: number;
-}) => {
-  return (
-    <div className="space-y-3 mb-4">
-      {/* 検索ボックス */}
-      <div className="relative">
-        <input
-          type="text"
-          placeholder="政策を検索..."
-          value={searchTerm}
-          onChange={(e) => onSearchChange(e.target.value)}
-          className="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#4AA0E9] focus:border-transparent"
-        />
-        <svg className="absolute right-3 top-2.5 w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-        </svg>
-      </div>
-
-      {/* ソート・表示件数 */}
-      <div className="flex justify-between items-center">
-        <select
-          value={sortBy}
-          onChange={(e) => onSortChange(e.target.value as "date" | "title")}
-          className="px-2 py-1 text-xs border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-[#4AA0E9]"
-        >
-          <option value="date">投稿日時順</option>
-          <option value="title">タイトル順</option>
-        </select>
-        
-        <span className="text-xs text-gray-500">
-          {totalItems}件中 {(currentPage - 1) * itemsPerPage + 1}-{Math.min(currentPage * itemsPerPage, totalItems)}件
-        </span>
-      </div>
-
-      {/* ページネーション */}
-      {totalPages > 1 && (
-        <div className="flex justify-center items-center space-x-1">
-          <button
-            onClick={() => onPageChange(currentPage - 1)}
-            disabled={currentPage === 1}
-            className="px-2 py-1 text-xs bg-gray-100 text-gray-600 rounded hover:bg-gray-200 disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            前へ
-          </button>
-          
-          {Array.from({ length: Math.min(5, totalPages) }, (_, i) => {
-            const page = i + 1;
-            if (totalPages <= 5) {
-              return page;
-            }
-            if (page === 1 || page === totalPages || (page >= currentPage - 1 && page <= currentPage + 1)) {
-              return page;
-            }
-            if (page === currentPage - 2 || page === currentPage + 2) {
-              return "...";
-            }
-            return null;
-          }).filter(Boolean).map((page, index) => (
-            <button
-              key={index}
-              onClick={() => typeof page === "number" ? onPageChange(page) : null}
-              disabled={page === "..."}
-              className={`px-2 py-1 text-xs rounded ${
-                page === currentPage
-                  ? "bg-[#4AA0E9] text-white"
-                  : page === "..."
-                  ? "text-gray-400 cursor-default"
-                  : "bg-gray-100 text-gray-600 hover:bg-gray-200"
-              }`}
-            >
-              {page}
-            </button>
-          ))}
-          
-          <button
-            onClick={() => onPageChange(currentPage + 1)}
-            disabled={currentPage === totalPages}
-            className="px-2 py-1 text-xs bg-gray-100 text-gray-600 rounded hover:bg-gray-200 disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            次へ
-          </button>
-        </div>
-      )}
-    </div>
-  );
-};
-
-// 政策投稿カードコンポーネント
-const PolicySubmissionCard = ({ 
-  policy, 
-  onViewComments,
-  isSelected = false
-}: { 
-  policy: PolicySubmission;
-  onViewComments: (policyId: string) => void;
-  isSelected?: boolean;
-}) => {
-  return (
-    <div 
-      className={`p-4 cursor-pointer transition-all ${
-        isSelected 
-          ? 'bg-[#4AA0E9]/10 border-l-4 border-[#4AA0E9]' 
-          : 'hover:bg-gray-50'
-      }`}
-      onClick={() => onViewComments(policy.id)}
-    >
-      <div className="flex justify-between items-start mb-2">
-        <h3 className={`text-sm font-medium ${isSelected ? 'text-[#4AA0E9]' : 'text-gray-700'} line-clamp-2`}>
-          {policy.title}
-        </h3>
-      </div>
-      
-      <div className="text-sm text-gray-500 mb-2">
-        {policy.submittedAt}
-      </div>
-      
-      <div className="flex justify-between items-center mt-2 text-sm text-gray-500">
-        <span>
-          コメント: <CommentCount 
-            policyProposalId={policy.id}
-            className="text-gray-500"
-            showIcon={false}
-          />
-        </span>
-        {policy.attachedFiles && policy.attachedFiles.length > 0 && (
-          <span>添付ファイル: {policy.attachedFiles.length}件</span>
-        )}
-      </div>
-    </div>
-  );
-};
-
-// 返信コメント表示コンポーネント
-const ReplyItem = ({ reply }: { reply: Comment }) => {
-  return (
-    <div className="ml-6 p-3 bg-gray-50 rounded-lg border-l-2 border-[#4AA0E9] mb-2">
-      <div className="flex justify-between items-start mb-2">
-        <div>
-          <div className="font-medium text-sm text-gray-900 leading-tight mb-1">{reply.author_name}</div>
-          <div className="flex items-center space-x-2">
-            <span className="text-xs text-gray-500 leading-tight">{reply.author_type}</span>
-            <span className="text-xs text-gray-400">•</span>
-            <span className="text-xs text-gray-500 leading-tight">{new Date(reply.posted_at).toLocaleDateString('ja-JP')}</span>
-          </div>
-        </div>
-      </div>
-      <p className="text-sm text-gray-700 leading-relaxed">{reply.comment_text}</p>
-    </div>
-  );
-};
-
-// コメント表示コンポーネント（一覧ビュー）
-const CommentItem = ({ 
-  comment, 
-  onFeedbackSubmit,
-  isSubmitting = false
-}: { 
-  comment: Comment; 
-  onFeedbackSubmit: (feedback: {
-    commentId: string;
-    overallRating: number;
-    empathyRating: number;
-    aiResponse: string;
-  }) => void;
-  isSubmitting?: boolean;
-}) => {
-  const hasFeedback = isFeedbackSubmitted(comment);
-  const [showFeedbackForm, setShowFeedbackForm] = useState(false);
-  const [showReplies, setShowReplies] = useState(false);
-  const [replies, setReplies] = useState<Comment[]>([]);
-  const [repliesLoading, setRepliesLoading] = useState(false);
-  const [replyCount, setReplyCount] = useState<number>(0);
-
-  // コンポーネントマウント時に返信件数を取得
-  useEffect(() => {
-    const loadReplyCount = async () => {
-      try {
-        const count = await fetchReplyCountByCommentId(comment.id);
-        setReplyCount(count);
-      } catch (error) {
-        console.error('返信件数取得エラー:', error);
-        // エラーメッセージを表示（オプション）
-        if (error instanceof Error) {
-          console.error('エラー詳細:', error.message);
-        }
-      }
-    };
-    loadReplyCount();
-  }, [comment.id]);
-
-  // 投稿完了後に返信件数と一覧を更新
-  useEffect(() => {
-    if (!isSubmitting) {
-      // 投稿が完了した後に返信件数を再取得
-      const updateReplyCount = async () => {
-        try {
-          const count = await fetchReplyCountByCommentId(comment.id);
-          if (count !== replyCount) {
-            setReplyCount(count);
-            
-            // 返信が表示されている場合は一覧も更新
-            if (showReplies) {
-              const response = await fetchRepliesByCommentId(comment.id);
-              setReplies(response.replies);
-            }
-          }
-        } catch (error) {
-          console.error('返信更新エラー:', error);
-        }
-      };
-      
-      // 少し遅延を入れてDBの更新を待つ
-      const timeoutId = setTimeout(updateReplyCount, 1000);
-      return () => clearTimeout(timeoutId);
-    }
-  }, [isSubmitting, comment.id, replyCount, showReplies]);
-
-  // 返信コメントを取得する関数
-  const loadReplies = async () => {
-    if (replies.length > 0 && !isSubmitting) {
-      setShowReplies(!showReplies);
-      return;
-    }
-
-    setRepliesLoading(true);
-    try {
-      const response = await fetchRepliesByCommentId(comment.id);
-      setReplies(response.replies);
-      setShowReplies(true);
-      
-      // 返信件数も更新
-      const count = await fetchReplyCountByCommentId(comment.id);
-      setReplyCount(count);
-    } catch (error) {
-      console.error('返信コメント取得エラー:', error);
-      // エラーメッセージを表示（オプション）
-      if (error instanceof Error) {
-        console.error('エラー詳細:', error.message);
-      }
-    } finally {
-      setRepliesLoading(false);
-    }
-  };
-
-  return (
-    <div className="bg-white p-4 mb-4 relative rounded-lg border border-gray-100 shadow-sm hover:shadow-md transition-all duration-300 hover:scale-[1.02] hover:border-gray-200">
-      {/* ステータス表示 */}
-      {hasFeedback && (
-        <div className="absolute top-3 right-3">
-          <span className="inline-flex items-center justify-center rounded-md bg-[#4AA0E9] text-white text-xs px-2 py-0.5 font-medium">
-            • 評価保存済み
-          </span>
-        </div>
-      )}
-      
-      <div className="flex justify-between items-start mb-3">
-        <div>
-          <div className="font-bold text-base text-gray-900 leading-tight mb-1">{comment.author_name}</div>
-          <div className="flex items-center space-x-2">
-            <span className="text-xs text-gray-500 leading-tight">{comment.author_type}</span>
-            <span className="text-xs text-gray-400">•</span>
-            <span className="text-xs text-gray-500 leading-tight">{new Date(comment.posted_at).toLocaleDateString('ja-JP')}</span>
-          </div>
-        </div>
-        {!hasFeedback && (
-          <button
-            onClick={() => setShowFeedbackForm(true)}
-            className="px-3 py-1 bg-[#4AA0E9] text-white text-xs rounded hover:bg-[#3a8fd9] transition-colors"
-          >
-            フィードバックを追加
-          </button>
-        )}
-      </div>
-      
-      <p className="text-sm text-gray-700 mb-4 leading-relaxed">{comment.comment_text}</p>
-      
-      {/* 返信表示ボタン */}
-      {replyCount > 0 && (
-        <div className="flex justify-between items-center mb-4">
-          <button
-            onClick={loadReplies}
-            disabled={repliesLoading}
-            className="flex items-center gap-1 text-xs text-[#4AA0E9] hover:text-[#3a8fd9] transition-colors disabled:opacity-50"
-          >
-          {repliesLoading ? (
-            <>
-              <svg className="w-3 h-3 animate-spin" fill="none" viewBox="0 0 24 24">
-                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-              </svg>
-              返信を取得中...
-            </>
-          ) : (
-            <>
-              <svg className={`w-3 h-3 transition-transform ${showReplies ? 'rotate-90' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-              </svg>
-              {showReplies ? '返信を隠す' : `返信を表示 (${replyCount})`}
-            </>
-          )}
-        </button>
-        </div>
-      )}
-
-      {/* 返信コメント表示 */}
-      {showReplies && replies.length > 0 && (
-        <div className="mb-4">
-          {replies.map((reply) => (
-            <ReplyItem key={reply.id} reply={reply} />
-          ))}
-        </div>
-      )}
-
-      {/* フィードバックフォーム（展開形式） */}
-      {showFeedbackForm && (
-        <div className="mt-4 border-t border-gray-200 pt-4">
-                                      <CommentFeedbackForm 
-                              commentId={comment.id} 
-                              onSubmit={async (feedback) => {
-                                await onFeedbackSubmit(feedback);
-                                setShowFeedbackForm(false);
-                              }}
-                              onClose={() => setShowFeedbackForm(false)}
-                              isSubmitting={isSubmitting}
-                            />
-        </div>
-      )}
-    </div>
-  );
-};
-
-// メインページコンポーネント
-export const PolicyCommentsPage = () => {
-  const [selectedPolicyId, setSelectedPolicyId] = useState<string>("");
+// 政策一覧のページネーション・フィルタリング用のカスタムフック
+const usePolicyList = () => {
   const [policies, setPolicies] = useState<PolicySubmission[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [activeTab, setActiveTab] = useState("all");
-  const [feedbackSubmitted, setFeedbackSubmitted] = useState<Set<string>>(new Set());
-  const [showSuccessMessage, setShowSuccessMessage] = useState(false);
-  const [successMessage, setSuccessMessage] = useState('');
-  const [successDescription, setSuccessDescription] = useState('');
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  
-  // 投稿履歴のページネーション・フィルタリング用の状態
   const [currentPage, setCurrentPage] = useState(1);
-  const [itemsPerPage] = useState(10); // 1ページあたりの表示件数
+  const [itemsPerPage] = useState(10);
   const [searchTerm, setSearchTerm] = useState("");
   const [sortBy, setSortBy] = useState<"date" | "title">("date");
-  
+
   // 政策投稿履歴を取得
   useEffect(() => {
     const loadPolicySubmissions = async () => {
@@ -699,11 +33,6 @@ export const PolicyCommentsPage = () => {
         setLoading(true);
         const data = await fetchMyPolicySubmissions();
         setPolicies(data);
-        
-        // 最初の政策を選択
-        if (data.length > 0 && !selectedPolicyId) {
-          setSelectedPolicyId(data[0].id);
-        }
       } catch (err) {
         console.error('政策投稿履歴取得エラー:', err);
         setError(err instanceof Error ? err.message : 'データの取得に失敗しました');
@@ -713,166 +42,136 @@ export const PolicyCommentsPage = () => {
     };
 
     loadPolicySubmissions();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // フィルタリング・ソート・ページネーション
+  const filteredPolicies = useMemo(() => {
+    return policies.filter(policy =>
+      policy.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      policy.content.toLowerCase().includes(searchTerm.toLowerCase())
+    );
+  }, [policies, searchTerm]);
 
-  
-  const handleViewComments = (policyId: string) => {
-    setSelectedPolicyId(policyId);
-  };
-
-  const handleFeedbackSubmit = async (feedback: {
-    commentId: string;
-    overallRating: number;
-    empathyRating: number;
-    aiResponse: string;
-  }) => {
-    setIsSubmitting(true);
-    try {
-      // 評価データを保存
-      await saveCommentEvaluation(feedback.commentId, {
-        overallRating: feedback.overallRating,
-        empathyRating: feedback.empathyRating,
-      });
-      
-      // AI返信をコメントとして投稿
-      if (feedback.aiResponse.trim()) {
-        const userInfo = getUserFromToken();
-        if (userInfo) {
-          await postAIResponse(feedback.commentId, feedback.aiResponse, {
-            author_type: userInfo.role as "admin" | "staff" | "contributor" | "viewer",
-            author_id: userInfo.userId,
-          });
-        } else {
-          throw new Error('ユーザー情報が取得できませんでした');
-        }
+  const sortedPolicies = useMemo(() => {
+    return [...filteredPolicies].sort((a, b) => {
+      if (sortBy === "date") {
+        return new Date(b.submittedAt).getTime() - new Date(a.submittedAt).getTime();
+      } else {
+        return a.title.localeCompare(b.title);
       }
-      
-      // コメント一覧を再取得して最新の状態に更新
-      if (selectedPolicyId) {
-        try {
-          // 少し遅延を入れてDBの更新を待つ
-          setTimeout(async () => {
-            try {
-              const updatedComments = await fetchCommentsByPolicyId(selectedPolicyId);
-              setComments(updatedComments);
-              
-              // フィードバック状態も更新
-              const feedbackStates = getFeedbackStates(updatedComments);
-              setFeedbackSubmitted(feedbackStates);
-            } catch (error) {
-              console.error('コメント再取得エラー:', error);
-            }
-          }, 500);
-        } catch (error) {
-          console.error('コメント更新エラー:', error);
-        }
-      }
-      
-      // 成功メッセージを表示
-      setSuccessMessage('フィードバックが正常に投稿されました');
-      setSuccessDescription('評価と返信が保存されました');
-      setShowSuccessMessage(true);
-    } catch (error) {
-      console.error('フィードバック送信エラー:', error);
-      alert('フィードバックの送信に失敗しました');
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-  
-  const [comments, setComments] = useState<Comment[]>([]);
-  const [commentsLoading, setCommentsLoading] = useState(false);
-  
-  const selectedPolicy = policies.find(p => p.id === selectedPolicyId);
-  
-  // コメントを取得
-  useEffect(() => {
-    if (selectedPolicyId) {
-      const loadComments = async () => {
-        setCommentsLoading(true);
-        setComments([]); // 新しい政策を選択したら一旦クリア
-        try {
-          // 少し遅延を入れてローディング状態を見せる
-          await new Promise(resolve => setTimeout(resolve, 300));
-          const fetchedComments = await fetchCommentsByPolicyId(selectedPolicyId);
-          setComments(fetchedComments);
-          
-          // フィードバック状態をデータベースから取得して更新
-          const feedbackStates = getFeedbackStates(fetchedComments);
-          setFeedbackSubmitted(feedbackStates);
-        } catch (error) {
-          console.error('コメント取得エラー:', error);
-          setComments([]);
-        } finally {
-          setCommentsLoading(false);
-        }
-      };
-      
-      loadComments();
-    }
-  }, [selectedPolicyId]);
-  
-  // コメントを親コメントと返信に分類
-  const { parentComments } = organizeComments(comments);
-  
-  // フィルタリング（親コメントのみ）
-  const filteredParentComments = parentComments.filter(comment => {
-    const isSubmitted = isFeedbackSubmitted(comment);
-    switch (activeTab) {
-      case "unfb":
-        return !isSubmitted;
-      case "fb":
-        return isSubmitted;
-      default:
-        return true;
-    }
-  });
-
-  // 投稿履歴のフィルタリング・ソート・ページネーション
-  const filteredPolicies = policies.filter(policy =>
-    policy.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
-    policy.content.toLowerCase().includes(searchTerm.toLowerCase())
-  );
-
-  const sortedPolicies = [...filteredPolicies].sort((a, b) => {
-    if (sortBy === "date") {
-      return new Date(b.submittedAt).getTime() - new Date(a.submittedAt).getTime();
-    } else {
-      return a.title.localeCompare(b.title);
-    }
-  });
+    });
+  }, [filteredPolicies, sortBy]);
 
   const totalPages = Math.ceil(sortedPolicies.length / itemsPerPage);
   const startIndex = (currentPage - 1) * itemsPerPage;
   const endIndex = startIndex + itemsPerPage;
   const currentPolicies = sortedPolicies.slice(startIndex, endIndex);
 
+  return {
+    policies,
+    loading,
+    error,
+    currentPolicies,
+    sortedPolicies,
+    currentPage,
+    totalPages,
+    itemsPerPage,
+    searchTerm,
+    sortBy,
+    setCurrentPage,
+    setSearchTerm,
+    setSortBy,
+  };
+};
+
+// メインページコンポーネント
+export const PolicyCommentsPage = () => {
+  const [selectedPolicyId, setSelectedPolicyId] = useState<string>("");
+  const [activeTab, setActiveTab] = useState("all");
+  
+  // カスタムフックを使用
+  const policyList = usePolicyList();
+  const { comments, loading: commentsLoading, refreshComments } = usePolicyComments(selectedPolicyId);
+  
+  const { 
+    isSubmitting, 
+    submitFeedback, 
+    successMessage, 
+    successDescription, 
+    showSuccessMessage, 
+    clearSuccessMessage 
+  } = useFeedbackSubmission(refreshComments);
+
+  // 最初の政策を選択
+  useEffect(() => {
+    if (policyList.currentPolicies.length > 0 && !selectedPolicyId) {
+      setSelectedPolicyId(policyList.currentPolicies[0].id);
+    }
+  }, [policyList.currentPolicies, selectedPolicyId]);
+
   // 検索やページ変更時に選択された政策が表示されない場合の処理
   useEffect(() => {
-    if (selectedPolicyId && !currentPolicies.find(p => p.id === selectedPolicyId)) {
-      // 選択された政策が現在のページにない場合、最初の政策を選択
-      if (currentPolicies.length > 0) {
-        setSelectedPolicyId(currentPolicies[0].id);
+    if (selectedPolicyId && !policyList.currentPolicies.find(p => p.id === selectedPolicyId)) {
+      if (policyList.currentPolicies.length > 0) {
+        setSelectedPolicyId(policyList.currentPolicies[0].id);
       } else {
         setSelectedPolicyId("");
       }
     }
-  }, [currentPolicies, selectedPolicyId]);
+  }, [policyList.currentPolicies, selectedPolicyId, policyList]);
 
   // 検索時にページを1に戻す
   useEffect(() => {
-    setCurrentPage(1);
-  }, [searchTerm, sortBy]);
+    policyList.setCurrentPage(1);
+  }, [policyList.searchTerm, policyList.sortBy]);
+
+  // コメントを親コメントと返信に分類
+  const { parentComments } = useMemo(() => 
+    organizeComments(comments), [comments]
+  );
+
+  // フィルタリング（親コメントのみ）
+  const filteredParentComments = useMemo(() => {
+    return parentComments.filter(comment => {
+      const isSubmitted = isFeedbackSubmitted(comment);
+      switch (activeTab) {
+        case "unfb":
+          return !isSubmitted;
+        case "fb":
+          return isSubmitted;
+        default:
+          return true;
+      }
+    });
+  }, [parentComments, activeTab]);
 
   // 件数計算（親コメントのみ）
-  const counts = {
+  const counts = useMemo(() => ({
     all: parentComments.length,
     unfb: parentComments.filter(c => !isFeedbackSubmitted(c)).length,
     fb: parentComments.filter(c => isFeedbackSubmitted(c)).length,
-  };
-  
+  }), [parentComments]);
+
+  const selectedPolicy = policyList.policies.find(p => p.id === selectedPolicyId);
+
+  const handleViewComments = useCallback((policyId: string) => {
+    setSelectedPolicyId(policyId);
+  }, []);
+
+  const handleFeedbackSubmit = useCallback(async (feedback: {
+    commentId: string;
+    overallRating: number;
+    empathyRating: number;
+    aiResponse: string;
+  }) => {
+    try {
+      await submitFeedback(feedback);
+    } catch (error) {
+      console.error('フィードバック送信エラー:', error);
+      alert('フィードバックの送信に失敗しました');
+    }
+  }, [submitFeedback]);
+
   return (
     <div className="relative min-h-screen w-full overflow-hidden">
       {/* 成功メッセージ */}
@@ -880,7 +179,7 @@ export const PolicyCommentsPage = () => {
         <SuccessMessage
           message={successMessage}
           description={successDescription}
-          onClose={() => setShowSuccessMessage(false)}
+          onClose={clearSuccessMessage}
           autoHide={true}
           duration={4000}
         />
@@ -931,95 +230,85 @@ export const PolicyCommentsPage = () => {
 
                 {/* 検索・フィルタリング・ページネーション */}
                 <PolicyListControls
-                  searchTerm={searchTerm}
-                  onSearchChange={setSearchTerm}
-                  sortBy={sortBy}
-                  onSortChange={setSortBy}
-                  currentPage={currentPage}
-                  totalPages={totalPages}
-                  onPageChange={setCurrentPage}
-                  totalItems={sortedPolicies.length}
-                  itemsPerPage={itemsPerPage}
+                  searchTerm={policyList.searchTerm}
+                  onSearchChange={policyList.setSearchTerm}
+                  sortBy={policyList.sortBy}
+                  onSortChange={policyList.setSortBy}
+                  currentPage={policyList.currentPage}
+                  totalPages={policyList.totalPages}
+                  onPageChange={policyList.setCurrentPage}
+                  totalItems={policyList.sortedPolicies.length}
+                  itemsPerPage={policyList.itemsPerPage}
                 />
                 
-                {loading ? (
+                {policyList.loading ? (
                   <div className="animate-fade-in-up">
                     <PolicySubmissionSkeletonList count={5} />
                   </div>
-                ) : error ? (
+                ) : policyList.error ? (
                   <div className="text-center py-8">
-                    <p className="text-red-500">{error}</p>
-                    <button 
-                      onClick={() => window.location.reload()}
-                      className="mt-2 px-3 py-1 bg-[#4AA0E9] text-white text-xs rounded hover:bg-[#3a8fd9] transition-colors"
-                    >
-                      再試行
-                    </button>
+                    <p className="text-red-500">{policyList.error}</p>
                   </div>
-                ) : policies.length === 0 ? (
-                  <div className="text-center py-8">
-                    <p className="text-gray-500">投稿履歴がありません</p>
-                  </div>
-                ) : (
-                  <div className="space-y-2">
-                    {currentPolicies.length > 0 ? (
-                      currentPolicies.map((policy) => (
-                        <PolicySubmissionCard 
-                          key={policy.id} 
-                          policy={policy} 
-                          onViewComments={handleViewComments}
-                          isSelected={policy.id === selectedPolicyId}
-                        />
-                      ))
-                    ) : (
-                      <div className="text-center py-8">
-                        <div className="flex flex-col items-center space-y-2">
-                          <svg className="w-8 h-8 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-                          </svg>
-                          <p className="text-sm text-gray-500">
-                            {searchTerm ? `"${searchTerm}" に一致する政策が見つかりません` : "政策がありません"}
-                          </p>
+                ) : policyList.currentPolicies.length > 0 ? (
+                  <div className="space-y-3">
+                    {policyList.currentPolicies.map((policy, index) => (
+                      <div 
+                        key={policy.id} 
+                        className={`animate-fade-in-up cursor-pointer transition-all duration-300 hover:scale-[1.02] ${
+                          selectedPolicyId === policy.id 
+                            ? 'bg-[#4AA0E9] text-white shadow-lg' 
+                            : 'bg-gray-50 hover:bg-gray-100'
+                        } rounded-lg p-3 min-h-[80px] flex flex-col justify-between`}
+                        style={{ animationDelay: `${index * 0.1}s` }}
+                        onClick={() => handleViewComments(policy.id)}
+                      >
+                        <div className="flex-1">
+                          <div className="flex justify-between items-start mb-2">
+                            <h3 className={`text-sm font-semibold leading-tight ${
+                              selectedPolicyId === policy.id ? 'text-white' : 'text-gray-900'
+                            }`} style={{
+                              display: '-webkit-box',
+                              WebkitLineClamp: 2,
+                              WebkitBoxOrient: 'vertical',
+                              overflow: 'hidden',
+                              textOverflow: 'ellipsis'
+                            }}>
+                              {policy.title}
+                            </h3>
+                            <span className={`text-xs ml-2 flex-shrink-0 ${
+                              selectedPolicyId === policy.id ? 'text-blue-100' : 'text-gray-500'
+                            }`}>
+                              {policy.commentCount} コメント
+                            </span>
+                          </div>
+                        </div>
+                        <div className={`text-xs mt-auto ${
+                          selectedPolicyId === policy.id ? 'text-blue-100' : 'text-gray-500'
+                        }`}>
+                          {policy.submittedAt}
                         </div>
                       </div>
-                    )}
+                    ))}
+                  </div>
+                ) : (
+                  <div className="text-center py-8">
+                    <p className="text-gray-500">政策が見つかりません</p>
                   </div>
                 )}
               </Card>
             </div>
           </div>
-          
-          {/* 右側: コメントエリア */}
+
+          {/* 右側: コメント一覧 */}
           <div className="xl:col-span-3 lg:col-span-2 order-1 lg:order-2">
-            <Card className="p-6 bg-white border-0">
-              {loading ? (
+            <Card className="p-4 lg:p-6 bg-white border-0">
+              {policyList.loading ? (
                 <div className="animate-fade-in-up">
-                  <div className="space-y-4">
-                    {Array.from({ length: 3 }).map((_, index) => (
-                      <div key={index} className="bg-white p-4 rounded-lg border border-gray-100 shadow-sm">
-                        <div className="flex justify-between items-start mb-3">
-                          <div className="flex-1">
-                            <div className="h-5 bg-gradient-to-r from-gray-200 via-gray-300 to-gray-200 rounded mb-2 animate-pulse-slow" style={{ width: '60%' }} />
-                            <div className="flex items-center space-x-2">
-                              <div className="h-3 bg-gradient-to-r from-gray-200 via-gray-300 to-gray-200 rounded animate-pulse-slow" style={{ width: '40%' }} />
-                              <div className="h-3 w-1 bg-gradient-to-r from-gray-200 via-gray-300 to-gray-200 rounded animate-pulse-slow" />
-                              <div className="h-3 bg-gradient-to-r from-gray-200 via-gray-300 to-gray-200 rounded animate-pulse-slow" style={{ width: '30%' }} />
-                            </div>
-                          </div>
-                          <div className="h-8 w-24 bg-gradient-to-r from-gray-200 via-gray-300 to-gray-200 rounded animate-pulse-slow" />
-                        </div>
-                        <div className="space-y-2 mb-4">
-                          <div className="h-4 bg-gradient-to-r from-gray-200 via-gray-300 to-gray-200 rounded animate-pulse-slow" />
-                          <div className="h-4 bg-gradient-to-r from-gray-200 via-gray-300 to-gray-200 rounded animate-pulse-slow" style={{ width: '95%' }} />
-                          <div className="h-4 bg-gradient-to-r from-gray-200 via-gray-300 to-gray-200 rounded animate-pulse-slow" style={{ width: '85%' }} />
-                        </div>
-                      </div>
-                    ))}
-                  </div>
+                  <CommentSkeletonList count={3} />
                 </div>
-              ) : error ? (
+              ) : policyList.error ? (
                 <div className="text-center py-8">
-                  <p className="text-red-500">{error}</p>
+                  <p className="text-red-500">{policyList.error}</p>
                 </div>
               ) : selectedPolicy ? (
                 <>
@@ -1044,7 +333,7 @@ export const PolicyCommentsPage = () => {
                   </div>
                   
                   {/* フィルタタブ */}
-                  <SimpleTabs 
+                  <FilterTabs 
                     activeTab={activeTab} 
                     onChange={setActiveTab}
                     counts={counts}
@@ -1072,33 +361,7 @@ export const PolicyCommentsPage = () => {
                         ))}
                       </div>
                     ) : (
-                      <div className="text-center py-12 animate-fade-in-up">
-                        <div className="flex flex-col items-center space-y-4">
-                          <div className="w-16 h-16 bg-gray-100 rounded-full flex items-center justify-center">
-                            <svg className="w-8 h-8 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-                            </svg>
-                          </div>
-                          <div className="text-center">
-                            <h3 className="text-lg font-medium text-gray-900 mb-2">
-                              {activeTab === "all" 
-                                ? "まだコメントがありません" 
-                                : activeTab === "unfb" 
-                                ? "未対応のコメントはありません"
-                                : "対応済みのコメントはありません"
-                              }
-                            </h3>
-                            <p className="text-gray-500 text-sm">
-                              {activeTab === "all" 
-                                ? "この政策に対するコメントがまだ投稿されていません。"
-                                : activeTab === "unfb" 
-                                ? "すべてのコメントが対応済みです。"
-                                : "まだ対応していないコメントはありません。"
-                              }
-                            </p>
-                          </div>
-                        </div>
-                      </div>
+                      <EmptyState activeTab={activeTab} />
                     )}
                   </div>
                 </>
@@ -1112,6 +375,104 @@ export const PolicyCommentsPage = () => {
         </div>
       </div>
     </div>
+    </div>
+  );
+};
+
+// PolicyListControlsコンポーネント（既存のコードから移植）
+const PolicyListControls = ({ 
+  searchTerm, 
+  onSearchChange, 
+  sortBy, 
+  onSortChange, 
+  currentPage, 
+  totalPages, 
+  onPageChange, 
+  totalItems, 
+  itemsPerPage 
+}: {
+  searchTerm: string;
+  onSearchChange: (value: string) => void;
+  sortBy: "date" | "title";
+  onSortChange: (value: "date" | "title") => void;
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+  totalItems: number;
+  itemsPerPage: number;
+}) => {
+  const startItem = (currentPage - 1) * itemsPerPage + 1;
+  const endItem = Math.min(currentPage * itemsPerPage, totalItems);
+
+  return (
+    <div className="space-y-4 mb-6">
+      {/* 検索バー */}
+      <div className="relative">
+        <input
+          type="text"
+          placeholder="政策を検索..."
+          value={searchTerm}
+          onChange={(e) => onSearchChange(e.target.value)}
+          className="w-full pl-10 pr-4 py-2 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#4AA0E9] focus:border-transparent"
+        />
+        <svg className="absolute left-3 top-2.5 w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+        </svg>
+      </div>
+
+      {/* ソート・ページネーション */}
+      <div className="flex justify-between items-center">
+        <select
+          value={sortBy}
+          onChange={(e) => onSortChange(e.target.value as "date" | "title")}
+          className="text-sm border border-gray-300 rounded px-2 py-1 focus:ring-2 focus:ring-[#4AA0E9] focus:border-transparent"
+        >
+          <option value="date">投稿日時順</option>
+          <option value="title">タイトル順</option>
+        </select>
+
+        <div className="flex items-center space-x-2 text-sm text-gray-500">
+          <span>{totalItems}件中 {startItem}-{endItem}件</span>
+        </div>
+      </div>
+
+      {/* ページネーション */}
+      {totalPages > 1 && (
+        <div className="flex justify-center space-x-1">
+          <button
+            onClick={() => onPageChange(currentPage - 1)}
+            disabled={currentPage === 1}
+            className="px-3 py-1 text-sm border border-gray-300 rounded hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            前へ
+          </button>
+          
+          {Array.from({ length: Math.min(5, totalPages) }, (_, i) => {
+            const page = Math.max(1, Math.min(totalPages - 4, currentPage - 2)) + i;
+            return (
+              <button
+                key={page}
+                onClick={() => onPageChange(page)}
+                className={`px-3 py-1 text-sm border rounded ${
+                  currentPage === page
+                    ? 'bg-[#4AA0E9] text-white border-[#4AA0E9]'
+                    : 'border-gray-300 hover:bg-gray-50'
+                }`}
+              >
+                {page}
+              </button>
+            );
+          })}
+          
+          <button
+            onClick={() => onPageChange(currentPage + 1)}
+            disabled={currentPage === totalPages}
+            className="px-3 py-1 text-sm border border-gray-300 rounded hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            次へ
+          </button>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/blocks/policy-comments/CommentFeedbackForm.tsx
+++ b/src/components/blocks/policy-comments/CommentFeedbackForm.tsx
@@ -1,0 +1,213 @@
+import React, { useState, useCallback } from 'react';
+import { generateAIResponse } from '@/lib/evaluation-api';
+
+interface CommentFeedbackFormProps {
+  commentId: string;
+  onSubmit: (feedback: {
+    commentId: string;
+    overallRating: number;
+    empathyRating: number;
+    aiResponse: string;
+  }) => void;
+  onClose: () => void;
+  isSubmitting?: boolean;
+}
+
+// 評価ボタンコンポーネント
+const RatingButtons = ({ 
+  value, 
+  onChange, 
+  label,
+  description,
+  leftLabel,
+  rightLabel
+}: { 
+  value: number; 
+  onChange: (value: number) => void; 
+  label: string;
+  description?: string;
+  leftLabel?: string;
+  rightLabel?: string;
+}) => {
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <span className="text-xs font-medium text-gray-700 min-w-[80px]">{label}:</span>
+        <div className="flex gap-1">
+          {[1, 2, 3, 4, 5].map((rating) => (
+            <div key={rating} className="flex flex-col items-center">
+              <button
+                onClick={() => onChange(rating)}
+                className={`w-6 h-6 rounded border transition-all hover:scale-105 ${
+                  value >= rating
+                    ? 'bg-[#4AA0E9] border-[#4AA0E9] text-white shadow-sm'
+                    : 'bg-white border-gray-300 text-gray-400 hover:border-[#4AA0E9]'
+                }`}
+              >
+                <span className="text-xs font-medium">{rating}</span>
+              </button>
+            </div>
+          ))}
+        </div>
+        {value > 0 && (
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-gray-500">{leftLabel}</span>
+            <span className="text-xs text-gray-400">→</span>
+            <span className="text-xs text-gray-500">{rightLabel}</span>
+          </div>
+        )}
+      </div>
+      {description && (
+        <p className="text-xs text-gray-500 ml-[88px]">{description}</p>
+      )}
+      {value > 0 && (
+        <div className="flex items-center gap-2 ml-[88px]">
+          <span className="text-xs text-gray-400">評価: </span>
+          <span className="text-xs font-medium text-[#4AA0E9]">{value}/5</span>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export const CommentFeedbackForm: React.FC<CommentFeedbackFormProps> = ({ 
+  commentId, 
+  onSubmit,
+  onClose,
+  isSubmitting = false
+}) => {
+  const [overallRating, setOverallRating] = useState(0);
+  const [empathyRating, setEmpathyRating] = useState(0);
+  const [aiResponse, setAiResponse] = useState('');
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [_evaluationSaved, _setEvaluationSaved] = useState(false);
+
+  const handleGenerateAIResponse = useCallback(async () => {
+    setIsGenerating(true);
+    try {
+      const response = await generateAIResponse(commentId, {
+        persona: "丁寧で建設的な政策担当者",
+        instruction: "具体的な提案を含めて返信してください"
+      });
+      setAiResponse(response.suggested_reply);
+    } catch (error) {
+      console.error('AI返信生成エラー:', error);
+      setAiResponse('AI返信の生成に失敗しました。もう一度お試しください。');
+    } finally {
+      setIsGenerating(false);
+    }
+  }, [commentId]);
+
+  const handleRegenerate = useCallback(async () => {
+    setIsGenerating(true);
+    try {
+      const response = await generateAIResponse(commentId, {
+        persona: "建設的で批判的な視点を持つ政策担当者",
+        instruction: "別の視点から、より詳細な分析を含めて返信してください"
+      });
+      setAiResponse(response.suggested_reply);
+    } catch (error) {
+      console.error('AI返信再生成エラー:', error);
+      setAiResponse('AI返信の再生成に失敗しました。もう一度お試しください。');
+    } finally {
+      setIsGenerating(false);
+    }
+  }, [commentId]);
+
+  const handleSubmit = useCallback(() => {
+    if (overallRating > 0 && empathyRating > 0 && aiResponse.trim()) {
+      onSubmit({
+        commentId,
+        overallRating,
+        empathyRating,
+        aiResponse
+      });
+    }
+  }, [commentId, overallRating, empathyRating, aiResponse, onSubmit]);
+
+  return (
+    <div className="bg-gray-50 rounded-lg p-4 space-y-4">
+      <div className="flex justify-between items-center">
+        <h3 className="text-sm font-semibold text-gray-900">フィードバック評価</h3>
+        <button
+          onClick={onClose}
+          className="text-gray-400 hover:text-gray-600 transition-colors"
+        >
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+
+      {/* 評価セクション */}
+      <div className="space-y-4">
+        <RatingButtons
+          value={overallRating}
+          onChange={setOverallRating}
+          label="総合評価"
+          description="コメントの内容や提案の質を評価してください"
+          leftLabel="低い"
+          rightLabel="高い"
+        />
+        
+        <RatingButtons
+          value={empathyRating}
+          onChange={setEmpathyRating}
+          label="共感度"
+          description="政策への共感や理解度を評価してください"
+          leftLabel="否定的"
+          rightLabel="肯定的"
+        />
+      </div>
+
+      {/* AI返信生成セクション */}
+      <div className="space-y-3">
+        <div className="flex justify-between items-center">
+          <h4 className="text-sm font-medium text-gray-900">AI返信生成</h4>
+          <div className="flex gap-2">
+            <button
+              onClick={handleGenerateAIResponse}
+              disabled={isGenerating}
+              className="px-3 py-1 bg-[#4AA0E9] text-white text-xs rounded hover:bg-[#3a8fd9] transition-colors disabled:opacity-50"
+            >
+              {isGenerating ? '生成中...' : '生成'}
+            </button>
+            {aiResponse && (
+              <button
+                onClick={handleRegenerate}
+                disabled={isGenerating}
+                className="px-3 py-1 bg-gray-500 text-white text-xs rounded hover:bg-gray-600 transition-colors disabled:opacity-50"
+              >
+                再生成
+              </button>
+            )}
+          </div>
+        </div>
+        
+        <textarea
+          value={aiResponse}
+          onChange={(e) => setAiResponse(e.target.value)}
+          placeholder="AIが生成した返信文案を編集できます..."
+          className="w-full h-32 p-3 text-sm border border-gray-300 rounded-lg resize-none focus:ring-2 focus:ring-[#4AA0E9] focus:border-transparent"
+        />
+      </div>
+
+      {/* 送信ボタン */}
+      <div className="flex justify-end gap-3 pt-2">
+        <button
+          onClick={onClose}
+          className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800 transition-colors"
+        >
+          キャンセル
+        </button>
+        <button
+          onClick={handleSubmit}
+          disabled={isSubmitting || overallRating === 0 || empathyRating === 0 || !aiResponse.trim()}
+          className="px-4 py-2 bg-[#4AA0E9] text-white text-sm rounded hover:bg-[#3a8fd9] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {isSubmitting ? '送信中...' : '送信'}
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/components/blocks/policy-comments/CommentItem.tsx
+++ b/src/components/blocks/policy-comments/CommentItem.tsx
@@ -1,0 +1,180 @@
+import React, { useState, useEffect, useCallback, memo } from 'react';
+import { Comment, isFeedbackSubmitted, fetchRepliesByCommentId, fetchReplyCountByCommentId } from '@/lib/comments-api';
+import { CommentFeedbackForm } from './CommentFeedbackForm';
+
+interface CommentItemProps {
+  comment: Comment;
+  onFeedbackSubmit: (feedback: {
+    commentId: string;
+    overallRating: number;
+    empathyRating: number;
+    aiResponse: string;
+  }) => void;
+  isSubmitting?: boolean;
+}
+
+export const CommentItem = memo<CommentItemProps>(({ 
+  comment, 
+  onFeedbackSubmit,
+  isSubmitting = false
+}) => {
+  const hasFeedback = isFeedbackSubmitted(comment);
+  const [showFeedbackForm, setShowFeedbackForm] = useState(false);
+  const [showReplies, setShowReplies] = useState(false);
+  const [replies, setReplies] = useState<Comment[]>([]);
+  const [repliesLoading, setRepliesLoading] = useState(false);
+  const [replyCount, setReplyCount] = useState<number>(0);
+
+  // コンポーネントマウント時に返信件数を取得
+  useEffect(() => {
+    const loadReplyCount = async () => {
+      try {
+        const count = await fetchReplyCountByCommentId(comment.id);
+        setReplyCount(count);
+      } catch (error) {
+        console.error('返信件数取得エラー:', error);
+      }
+    };
+    loadReplyCount();
+  }, [comment.id]);
+
+  // 投稿完了後に返信件数と一覧を更新
+  useEffect(() => {
+    if (!isSubmitting) {
+      const updateReplyCount = async () => {
+        try {
+          const count = await fetchReplyCountByCommentId(comment.id);
+          if (count !== replyCount) {
+            setReplyCount(count);
+            
+            // 返信が表示されている場合は一覧も更新
+            if (showReplies) {
+              const response = await fetchRepliesByCommentId(comment.id);
+              setReplies(response.replies);
+            }
+          }
+        } catch (error) {
+          console.error('返信更新エラー:', error);
+        }
+      };
+      
+      const timeoutId = setTimeout(updateReplyCount, 1000);
+      return () => clearTimeout(timeoutId);
+    }
+  }, [isSubmitting, comment.id, replyCount, showReplies]);
+
+  // 返信コメントを取得する関数
+  const loadReplies = useCallback(async () => {
+    if (replies.length > 0 && !isSubmitting) {
+      setShowReplies(!showReplies);
+      return;
+    }
+
+    setRepliesLoading(true);
+    try {
+      const response = await fetchRepliesByCommentId(comment.id);
+      setReplies(response.replies);
+      setShowReplies(true);
+      
+      // 返信件数も更新
+      const count = await fetchReplyCountByCommentId(comment.id);
+      setReplyCount(count);
+    } catch (error) {
+      console.error('返信コメント取得エラー:', error);
+    } finally {
+      setRepliesLoading(false);
+    }
+  }, [comment.id, replies.length, isSubmitting, showReplies]);
+
+  const handleFeedbackSubmit = useCallback(async (feedback: {
+    commentId: string;
+    overallRating: number;
+    empathyRating: number;
+    aiResponse: string;
+  }) => {
+    await onFeedbackSubmit(feedback);
+    setShowFeedbackForm(false);
+  }, [onFeedbackSubmit]);
+
+  return (
+    <div className="bg-white p-4 mb-4 relative rounded-lg border border-gray-100 shadow-sm hover:shadow-md transition-all duration-300 hover:scale-[1.02] hover:border-gray-200">
+      {/* ステータス表示 */}
+      {hasFeedback && (
+        <div className="absolute top-3 right-3">
+          <span className="inline-flex items-center justify-center rounded-md bg-[#4AA0E9] text-white text-xs px-2 py-0.5 font-medium">
+            • 評価保存済み
+          </span>
+        </div>
+      )}
+      
+      <div className="flex justify-between items-start mb-3">
+        <div>
+          <div className="font-bold text-base text-gray-900 leading-tight mb-1">{comment.author_name}</div>
+          <div className="flex items-center space-x-2">
+            <span className="text-xs text-gray-500 leading-tight">{comment.author_type}</span>
+            <span className="text-xs text-gray-400">•</span>
+            <span className="text-xs text-gray-500 leading-tight">{new Date(comment.posted_at).toLocaleDateString('ja-JP')}</span>
+          </div>
+        </div>
+        {!hasFeedback && (
+          <button
+            onClick={() => setShowFeedbackForm(true)}
+            className="px-3 py-1 bg-[#4AA0E9] text-white text-xs rounded hover:bg-[#3a8fd9] transition-colors"
+          >
+            フィードバックを追加
+          </button>
+        )}
+      </div>
+      
+      <p className="text-sm text-gray-700 mb-4 leading-relaxed">{comment.comment_text}</p>
+      
+      {/* 返信表示ボタン */}
+      {replyCount > 0 && (
+        <div className="border-t border-gray-100 pt-3">
+          <button
+            onClick={loadReplies}
+            disabled={repliesLoading}
+            className="flex items-center space-x-2 text-sm text-[#4AA0E9] hover:text-[#3a8fd9] transition-colors disabled:opacity-50"
+          >
+            <span>{showReplies ? '返信を隠す' : '返信を表示'}</span>
+            <span className="text-gray-500">({replyCount})</span>
+            {repliesLoading && (
+              <div className="w-4 h-4 border-2 border-[#4AA0E9] border-t-transparent rounded-full animate-spin"></div>
+            )}
+          </button>
+          
+          {/* 返信一覧 */}
+          {showReplies && replies.length > 0 && (
+            <div className="mt-3 space-y-3 pl-4 border-l-2 border-gray-100">
+              {replies.map((reply) => (
+                <div key={reply.id} className="bg-gray-50 p-3 rounded-lg">
+                  <div className="flex items-center space-x-2 mb-2">
+                    <span className="font-medium text-sm text-gray-900">{reply.author_name}</span>
+                    <span className="text-xs text-gray-500">{reply.author_type}</span>
+                    <span className="text-xs text-gray-400">•</span>
+                    <span className="text-xs text-gray-500">{new Date(reply.posted_at).toLocaleDateString('ja-JP')}</span>
+                  </div>
+                  <p className="text-sm text-gray-700 leading-relaxed">{reply.comment_text}</p>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* フィードバックフォーム（展開形式） */}
+      {showFeedbackForm && (
+        <div className="mt-4 border-t border-gray-200 pt-4">
+          <CommentFeedbackForm 
+            commentId={comment.id} 
+            onSubmit={handleFeedbackSubmit}
+            onClose={() => setShowFeedbackForm(false)}
+            isSubmitting={isSubmitting}
+          />
+        </div>
+      )}
+    </div>
+  );
+});
+
+CommentItem.displayName = 'CommentItem';

--- a/src/components/blocks/policy-comments/EmptyState.tsx
+++ b/src/components/blocks/policy-comments/EmptyState.tsx
@@ -1,0 +1,55 @@
+import React, { memo } from 'react';
+
+interface EmptyStateProps {
+  activeTab: string;
+}
+
+export const EmptyState = memo<EmptyStateProps>(({ activeTab }) => {
+  const getTitle = () => {
+    switch (activeTab) {
+      case "all":
+        return "まだコメントがありません";
+      case "unfb":
+        return "未対応のコメントはありません";
+      case "fb":
+        return "対応済みのコメントはありません";
+      default:
+        return "コメントがありません";
+    }
+  };
+
+  const getDescription = () => {
+    switch (activeTab) {
+      case "all":
+        return "この政策に対するコメントがまだ投稿されていません。";
+      case "unfb":
+        return "すべてのコメントが対応済みです。";
+      case "fb":
+        return "まだ対応していないコメントはありません。";
+      default:
+        return "コメントがありません。";
+    }
+  };
+
+  return (
+    <div className="text-center py-12 animate-fade-in-up">
+      <div className="flex flex-col items-center space-y-4">
+        <div className="w-16 h-16 bg-gray-100 rounded-full flex items-center justify-center">
+          <svg className="w-8 h-8 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+          </svg>
+        </div>
+        <div className="text-center">
+          <h3 className="text-lg font-medium text-gray-900 mb-2">
+            {getTitle()}
+          </h3>
+          <p className="text-gray-500 text-sm">
+            {getDescription()}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+});
+
+EmptyState.displayName = 'EmptyState';

--- a/src/components/blocks/policy-comments/FilterTabs.tsx
+++ b/src/components/blocks/policy-comments/FilterTabs.tsx
@@ -1,0 +1,43 @@
+import React, { memo } from 'react';
+
+interface FilterTabsProps {
+  activeTab: string;
+  onChange: (id: string) => void;
+  counts: { all: number; unfb: number; fb: number; };
+}
+
+const tabs = [
+  { id: "all", label: "すべて" },
+  { id: "unfb", label: "未FBのみ" },
+  { id: "fb", label: "FB済みのみ" },
+];
+
+export const FilterTabs = memo<FilterTabsProps>(({ activeTab, onChange, counts }) => {
+  return (
+    <div className="flex border-b border-gray-200 mb-6">
+      {tabs.map((tab) => {
+        const count = counts[tab.id as keyof typeof counts];
+        return (
+          <button
+            key={tab.id}
+            onClick={() => onChange(tab.id)}
+            className={`px-4 py-2 text-sm font-medium transition-colors ${
+              activeTab === tab.id 
+                ? "border-b-2 border-[#4AA0E9] text-[#4AA0E9]" 
+                : "text-gray-500 hover:text-gray-700"
+            }`}
+          >
+            {tab.label}
+            {count > 0 && (
+              <span className="ml-2 bg-gray-100 text-gray-600 px-2 py-0.5 rounded-full text-xs">
+                {count}
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+});
+
+FilterTabs.displayName = 'FilterTabs';

--- a/src/hooks/useFeedbackSubmission.ts
+++ b/src/hooks/useFeedbackSubmission.ts
@@ -1,0 +1,82 @@
+import { useState, useCallback } from 'react';
+import { saveCommentEvaluation, postAIResponse } from '@/lib/evaluation-api';
+import { getUserFromToken } from '@/lib/auth';
+
+interface FeedbackData {
+  commentId: string;
+  overallRating: number;
+  empathyRating: number;
+  aiResponse: string;
+}
+
+interface UseFeedbackSubmissionReturn {
+  isSubmitting: boolean;
+  submitFeedback: (feedback: FeedbackData) => Promise<void>;
+  successMessage: string;
+  successDescription: string;
+  showSuccessMessage: boolean;
+  clearSuccessMessage: () => void;
+}
+
+export const useFeedbackSubmission = (
+  onSuccess?: () => void
+): UseFeedbackSubmissionReturn => {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [successMessage, setSuccessMessage] = useState('');
+  const [successDescription, setSuccessDescription] = useState('');
+  const [showSuccessMessage, setShowSuccessMessage] = useState(false);
+
+  const submitFeedback = useCallback(async (feedback: FeedbackData) => {
+    setIsSubmitting(true);
+    
+    try {
+      // 評価データを保存
+      await saveCommentEvaluation(feedback.commentId, {
+        overallRating: feedback.overallRating,
+        empathyRating: feedback.empathyRating,
+      });
+      
+      // AI返信をコメントとして投稿
+      if (feedback.aiResponse.trim()) {
+        const userInfo = getUserFromToken();
+        if (userInfo) {
+          await postAIResponse(feedback.commentId, feedback.aiResponse, {
+            author_type: userInfo.role as "admin" | "staff" | "contributor" | "viewer",
+            author_id: userInfo.userId,
+          });
+        } else {
+          throw new Error('ユーザー情報が取得できませんでした');
+        }
+      }
+      
+      // 成功メッセージを表示
+      setSuccessMessage('フィードバックが正常に投稿されました');
+      setSuccessDescription('評価と返信が保存されました');
+      setShowSuccessMessage(true);
+      
+      // コールバックを実行
+      onSuccess?.();
+      
+    } catch (error) {
+      console.error('フィードバック送信エラー:', error);
+      throw new Error('フィードバックの送信に失敗しました');
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [onSuccess]);
+
+  const clearSuccessMessage = useCallback(() => {
+    setShowSuccessMessage(false);
+    setSuccessMessage('');
+    setSuccessDescription('');
+  }, []);
+
+  return {
+    isSubmitting,
+    submitFeedback,
+    successMessage,
+    successDescription,
+    showSuccessMessage,
+    clearSuccessMessage,
+  };
+};

--- a/src/hooks/usePolicyComments.ts
+++ b/src/hooks/usePolicyComments.ts
@@ -1,0 +1,58 @@
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { Comment } from '@/lib/comments-api';
+import { fetchCommentsByPolicyId, getFeedbackStates } from '@/lib/comments-api';
+
+interface UsePolicyCommentsReturn {
+  comments: Comment[];
+  loading: boolean;
+  error: string | null;
+  feedbackStates: Set<string>;
+  refreshComments: () => Promise<void>;
+}
+
+export const usePolicyComments = (policyId: string | null): UsePolicyCommentsReturn => {
+  const [comments, setComments] = useState<Comment[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // フィードバック状態をメモ化して不要な再計算を防ぐ
+  const feedbackStates = useMemo(() => 
+    getFeedbackStates(comments), [comments]
+  );
+
+  const loadComments = useCallback(async () => {
+    if (!policyId) return;
+    
+    setLoading(true);
+    setError(null);
+    
+    try {
+      const fetchedComments = await fetchCommentsByPolicyId(policyId);
+      setComments(fetchedComments);
+    } catch (err) {
+      console.error('コメント取得エラー:', err);
+      setError(err instanceof Error ? err.message : 'コメントの取得に失敗しました');
+      setComments([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [policyId]);
+
+  // コメント一覧を再取得する関数
+  const refreshComments = useCallback(async () => {
+    await loadComments();
+  }, [loadComments]);
+
+  // 政策IDが変更された時にコメントを取得
+  useEffect(() => {
+    loadComments();
+  }, [loadComments]);
+
+  return {
+    comments,
+    loading,
+    error,
+    feedbackStates,
+    refreshComments,
+  };
+};

--- a/src/lib/comments-api.ts
+++ b/src/lib/comments-api.ts
@@ -124,3 +124,22 @@ export function organizeComments(comments: Comment[]): {
   
   return { parentComments, repliesByParent };
 }
+
+// フィードバック状態を判定する関数
+export function isFeedbackSubmitted(comment: Comment): boolean {
+  // evaluationとstanceの両方が入力されている場合、フィードバック済みと判定
+  return comment.evaluation !== null && comment.stance !== null;
+}
+
+// コメント一覧からフィードバック状態を取得する関数
+export function getFeedbackStates(comments: Comment[]): Set<string> {
+  const feedbackSubmitted = new Set<string>();
+  
+  comments.forEach(comment => {
+    if (isFeedbackSubmitted(comment)) {
+      feedbackSubmitted.add(comment.id);
+    }
+  });
+  
+  return feedbackSubmitted;
+}

--- a/src/lib/policy-api.ts
+++ b/src/lib/policy-api.ts
@@ -17,6 +17,7 @@ export interface PolicySubmissionResponse {
   status: string;
   created_at: string;
   updated_at: string;
+  comment_count: number;
 }
 
 // PolicySubmissionResponseをPolicySubmissionに変換
@@ -28,7 +29,7 @@ function convertToPolicySubmission(response: PolicySubmissionResponse): PolicySu
     policyThemes: [], // APIからは取得できないため空配列
     submittedAt: response.created_at,
     status: response.status as PolicySubmission['status'],
-    commentCount: 0, // APIからは取得できないため0
+    commentCount: response.comment_count,
   };
 }
 


### PR DESCRIPTION
### 🎯 概要
PolicyCommentsPageのパフォーマンスと保守性を大幅に改善し、フィードバック状態の管理ロジックを修正しました。

### 🔧 主な変更点

#### 1. **フィードバック状態管理の修正**
- **問題**: ローカル状態（`Set<string>`）でフィードバック状態を管理していたため、ページリロード時に状態が初期化される
- **解決**: データベースの`evaluation`と`stance`フィールドを基準にフィードバック状態を判定
- **効果**: 「FB済みのみ」タブで正しくコメントが表示されるようになった

#### 2. **コンポーネントの分離と最適化**
- **問題**: 1117行の巨大な単一ファイルで保守性が低い
- **解決**: 以下のコンポーネントに分離
  - `CommentItem.tsx` (メモ化済み)
  - `CommentFeedbackForm.tsx`
  - `FilterTabs.tsx` (メモ化済み)
  - `EmptyState.tsx` (メモ化済み)
- **効果**: コードの可読性と保守性が向上

#### 3. **カスタムフックの追加**
- `usePolicyComments.ts`: コメント取得とフィードバック状態管理
- `useFeedbackSubmission.ts`: フィードバック送信ロジック
- **効果**: ビジネスロジックとUIの分離、再利用性の向上

#### 4. **コメント数表示の修正**
- **問題**: コメント数が常に0で表示される
- **解決**: バックエンドAPIレスポンスの`comment_count`フィールドを使用
- **効果**: 実際のコメント数が正しく表示される

#### 5. **UI/UXの改善**
- カードサイズの統一（`min-h-[80px]`）
- タイトルを2行に制限するスタイル追加
- レイアウトの一貫性向上

### �� パフォーマンス改善
- メモ化による不要な再レンダリングの防止
- コンポーネント分離による最適化
- カスタムフックによる効率的な状態管理

### �� 修正された問題
- [x] フィードバック状態がページリロード時に初期化される
- [x] 「FB済みのみ」タブでコメントが表示されない
- [x] コメント数が常に0で表示される
- [x] カードサイズが不統一
- [x] ESLintエラーと警告

### �� テスト
- [x] ビルド成功確認
- [x] ESLintエラー解消確認
- [x] フィードバック状態の正しい表示確認

### 📁 変更ファイル
```
src/components/blocks/PolicyCommentsPage.tsx (大幅リファクタリング)
src/components/blocks/policy-comments/CommentItem.tsx (新規)
src/components/blocks/policy-comments/CommentFeedbackForm.tsx (新規)
src/components/blocks/policy-comments/FilterTabs.tsx (新規)
src/components/blocks/policy-comments/EmptyState.tsx (新規)
src/hooks/usePolicyComments.ts (新規)
src/hooks/useFeedbackSubmission.ts (新規)
src/lib/policy-api.ts (コメント数取得修正)
```

### 🔄 破壊的変更
なし

### �� 追加情報
- バックエンドAPIの`comment_count`フィールドを使用するように修正
- フィードバック状態は`evaluation`と`stance`の両方が入力されている場合に「済み」と判定